### PR TITLE
3.5.3 Correção de valor total do pedido quando exitem taxas de entrega

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "3.5.2"
+        custom_tag: "3.5.3"
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.5.3 - 14/01/2025
+- Correção de valor total do pedido quando exitem taxas de entrega.
+
 # 3.5.2 - 18/12/2024
 - Correção de erro fatal em chamada de função de tradução.
 

--- a/Includes/LknIntegrationRedeForWoocommerceHelper.php
+++ b/Includes/LknIntegrationRedeForWoocommerceHelper.php
@@ -3,18 +3,11 @@ namespace Lkn\IntegrationRedeForWoocommerce\Includes;
 
 abstract class LknIntegrationRedeForWoocommerceHelper {
     final public static function getCartTotal() {
-        $cart = WC()->cart;
-
-        if (empty($cart)) {
+        global $woocommerce;
+        if (empty($woocommerce)) {
             return 0;
         }
-        $cart_items = $cart->get_cart();
-        $total = 0;
-        foreach ($cart_items as $cart_item_key => $cart_item) {
-            $product = $cart_item['data'];
-            $total += $product->get_price() * $cart_item['quantity'];
-        }
-        return $total;
+        return (float) $woocommerce->cart->total;
     }
     
     final public static function updateFixLoadScriptOption($id): void {

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: woocommerce,payment,card,credit
 Requires at least: 5.0
 Tested up to: 6.7
-Stable tag: 3.5.2
+Stable tag: 3.5.3
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -72,8 +72,11 @@ The Integration Rede for WooCommerce plugin is now live and working.
 * Have installed the WooCommerce plugin.
 
 == Changelog ==
+= 3.5.3 = *2025/01/14*
+* Fix order total when delivery fees are applied.
+
 = 3.5.2 = *2024/12/18*
-* Fix fatal error in translation function call
+* Fix fatal error in translation function call.
 
 = 3.5.1 = *2024/12/13*
 * Security correction in the card CVV (debit and credit).
@@ -191,6 +194,9 @@ The Integration Rede for WooCommerce plugin is now live and working.
 8. Rede and Maxipago payment list.
 
 == Upgrade Notice ==
+= 3.5.3 =
+* Fix order total when delivery fees are applied.
+
 = 3.5.2 =
 * Fix fatal error in translation function call
 

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede for WooCommerce
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           3.5.2
+ * Version:           3.5.3
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/wordpress
  * License:           GPL-3.0+

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.5.2');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.5.3');
 }
 
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_FILE')) {


### PR DESCRIPTION
- Correção de valor total do pedido quando exitem taxas de entrega
> A taxa de parcelas exibida para o usuário não estava somando a taxa de entrega ao valor total do pedido. Esse comportamento foi ajustado, e agora a soma considera corretamente a taxa de entrega.
![image](https://github.com/user-attachments/assets/bed907b1-f8d3-4407-9f5a-907f07540654)
