### PR TITLE
3.6.4 Correção de transações da MaxiPago não reconhecidas

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "3.6.2"
+        custom_tag: "3.6.3"
 
     # Generate new release
     - name: Generate new Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "3.6.3"
+        custom_tag: "3.6.4"
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.6.3 - 24/02/2025
+- Correção configurações quando o plugin PRO está desativado.
+
 # 3.6.2 - 03/02/2025
 - Correção em validação do campo de CVV.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.6.4 - 27/02/2025
+- Adição de conversão do valor total da compra.
+
 # 3.6.3 - 24/02/2025
 - Correção configurações quando o plugin PRO está desativado.
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
@@ -344,6 +344,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             $order_total = apply_filters('integrationRedeGetInterest', $order_total, $interest, $interest, 'total');
         }
 
+        $order_total = (float) $order_total;
         $creditExpiry = isset($_POST['maxipago_credit_expiry']) ? sanitize_text_field(wp_unslash($_POST['maxipago_credit_expiry'])) : 0;
 
         if (strpos($creditExpiry, '/') !== false) {

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
@@ -321,10 +321,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         $merchantId = sanitize_text_field($this->get_option('merchant_id'));
         $companyName = sanitize_text_field($this->get_option('company_name'));
         $merchantKey = sanitize_text_field($this->get_option('merchant_key'));
-        $capture = true;
-        /* if (is_plugin_active('rede-for-woocommerce-pro/rede-for-woocommerce-pro.php')) {
-            $capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? 'auth' : 'sale';
-        } */
+        $capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? 'auth' : 'sale';
         $referenceNum = uniqid('order_', true);
 
         $installments = isset($_POST['maxipago_credit_installments']) ?
@@ -471,7 +468,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             $xml_encode = wp_json_encode($xml);
             $xml_decode = json_decode($xml_encode, true);
 
-            if (isset($xml_decode['processorCode']) && "00" == $xml_decode['processorCode']) {
+            if (isset($xml_decode['responseCode']) && "0" == $xml_decode['responseCode']) {
                 $order->update_meta_data('_wc_maxipago_transaction_return_message', $xml_decode['processorMessage']);
                 $order->update_meta_data('_wc_maxipago_transaction_installments', $installments);
                 $order->update_meta_data('_wc_maxipago_transaction_id', $xml_decode['orderID']);

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
@@ -330,7 +330,10 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         $merchantId = sanitize_text_field($this->get_option('merchant_id'));
         $companyName = sanitize_text_field($this->get_option('company_name'));
         $merchantKey = sanitize_text_field($this->get_option('merchant_key'));
-        $capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? 'auth' : 'sale';
+        $capture = true;
+        if (is_plugin_active('rede-for-woocommerce-pro/rede-for-woocommerce-pro.php')) {
+            $capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? 'auth' : 'sale';
+        }
         $referenceNum = uniqid('order_', true);
 
         $installments = isset($_POST['maxipago_credit_installments']) ?

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
@@ -6,10 +6,8 @@ use Exception;
 use WC_Order;
 use WP_Error;
 
-final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrationRedeForWoocommerceWcRedeAbstract
-{
-    public function __construct()
-    {
+final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrationRedeForWoocommerceWcRedeAbstract {
+    public function __construct() {
         $this->id = 'maxipago_credit';
         $this->method_title = esc_attr__('Pay with the Maxipago Credit', 'woo-rede');
         $this->method_description = esc_attr__('Enables and configures payments with Maxipago Credit', 'woo-rede');
@@ -47,8 +45,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
      *
      * @return bool
      */
-    public function validate_fields()
-    {
+    public function validate_fields() {
         if (empty(sanitize_text_field(wp_unslash($_POST['maxipago_credit_card_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cnpj'])))) {
             wc_add_notice(esc_attr__('CPF is a required field', 'woo-rede'), 'error');
 
@@ -73,7 +70,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             return false;
         }
 
-        if (! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_credit_cvc'])))) {
+        if ( ! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_credit_cvc'])))) {
             wc_add_notice(esc_attr__('Card security code must be a numeric value', 'woo-rede'), 'error');
             return false;
         }
@@ -92,9 +89,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return true;
     }
 
-    public function addNeighborhoodFieldToCheckout($fields)
-    {
-        if (! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
+    public function addNeighborhoodFieldToCheckout($fields) {
+        if ( ! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
             && $this->is_available()) {
             $fields['billing']['billing_neighborhood'] = array(
                 'label' => __('District', 'woo-rede'),
@@ -120,8 +116,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
      *
      * @return array
      */
-    public function getConfigsMaxipagoCredit()
-    {
+    public function getConfigsMaxipagoCredit() {
         $configs = array();
 
         $configs['basePath'] = INTEGRATION_REDE_FOR_WOOCOMMERCE_DIR . 'Includes/logs/';
@@ -131,8 +126,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return $configs;
     }
 
-    public function initFormFields(): void
-    {
+    public function initFormFields(): void {
         LknIntegrationRedeForWoocommerceHelper::updateFixLoadScriptOption($this->id);
 
         $this->form_fields = array(
@@ -257,13 +251,12 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             'max_parcels_number' => $this->get_option('max_parcels_number'),
         ), $this->id);
 
-        if (! empty($customConfigs)) {
+        if ( ! empty($customConfigs)) {
             $this->form_fields = array_merge($this->form_fields, $customConfigs);
         }
     }
 
-    protected function getCheckoutForm($order_total = 0): void
-    {
+    protected function getCheckoutForm($order_total = 0): void {
         wc_get_template(
             'creditCard/maxipagoPaymentCreditForm.php',
             array(
@@ -274,8 +267,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         );
     }
 
-    public function getInstallments($order_total = 0)
-    {
+    public function getInstallments($order_total = 0) {
         $installments = array();
         $customLabel = null;
         $defaults = array(
@@ -311,8 +303,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return $installments;
     }
 
-    public function process_payment($orderId)
-    {
+    public function process_payment($orderId) {
         if (isset($_POST['maxipago_card_nonce']) && ! wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['maxipago_card_nonce'])), 'maxipagoCardNonce')) {
             return array(
                 'result' => 'fail',
@@ -331,9 +322,9 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         $companyName = sanitize_text_field($this->get_option('company_name'));
         $merchantKey = sanitize_text_field($this->get_option('merchant_key'));
         $capture = true;
-        if (is_plugin_active('rede-for-woocommerce-pro/rede-for-woocommerce-pro.php')) {
+        /* if (is_plugin_active('rede-for-woocommerce-pro/rede-for-woocommerce-pro.php')) {
             $capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? 'auth' : 'sale';
-        }
+        } */
         $referenceNum = uniqid('order_', true);
 
         $installments = isset($_POST['maxipago_credit_installments']) ?
@@ -403,7 +394,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
                 throw new Exception(__('Invalid number of installments', 'woo-rede'));
             }
 
-            if (! $this->validateCpfCnpj($clientData['billing_cpf'])) {
+            if ( ! $this->validateCpfCnpj($clientData['billing_cpf'])) {
                 throw new Exception(__("Please enter a valid cpf number", 'woo-rede'));
             }
             if ('production' === $environment) {
@@ -480,7 +471,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             $xml_encode = wp_json_encode($xml);
             $xml_decode = json_decode($xml_encode, true);
 
-            if ("APPROVED" == $xml_decode['processorMessage']) {
+            if (isset($xml_decode['processorCode']) && "00" == $xml_decode['processorCode']) {
                 $order->update_meta_data('_wc_maxipago_transaction_return_message', $xml_decode['processorMessage']);
                 $order->update_meta_data('_wc_maxipago_transaction_installments', $installments);
                 $order->update_meta_data('_wc_maxipago_transaction_id', $xml_decode['orderID']);
@@ -519,7 +510,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
                 throw new Exception($xml_decode['errorMessage']);
             }
             //Caso não exista nenhuma das Message, o Merchant ID ou Merchant Key estão invalidos
-            if (! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
+            if ( ! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
                 throw new Exception(__("Merchant ID or Merchant Key is invalid!", 'woo-rede'));
             }
 
@@ -539,8 +530,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         );
     }
 
-    public function process_refund($order_id, $amount = null, $reason = '')
-    {
+    public function process_refund($order_id, $amount = null, $reason = '') {
         $order = new WC_Order($order_id);
         $totalAmount = $order->get_meta('_wc_maxipago_total_amount');
         $environment = $this->get_option('environment');
@@ -634,8 +624,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return false;
     }
 
-    public function validateCpfCnpj($cpfCnpj)
-    {
+    public function validateCpfCnpj($cpfCnpj) {
         // Remove caracteres especiais
         $cpfCnpj = preg_replace('/[^0-9]/', '', $cpfCnpj);
 
@@ -701,8 +690,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return false;
     }
 
-    public function displayMeta($order): void
-    {
+    public function displayMeta($order): void {
         if ($order->get_payment_method() === 'maxipago_credit') {
             $metaKeys = array(
                 '_wc_maxipago_transaction_environment' => esc_attr__('Environment', 'woo-rede'),
@@ -722,18 +710,17 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         }
     }
 
-    public function checkoutScripts(): void
-    {
+    public function checkoutScripts(): void {
         $plugin_url = plugin_dir_url(LknIntegrationRedeForWoocommerceWcRede::FILE) . '../';
         if ($this->get_option('enabled_fix_load_script') === 'yes') {
             wp_enqueue_script('fixInfiniteLoading-js', $plugin_url . 'Public/js/fixInfiniteLoading.js', array(), '1.0.0', true);
         }
 
-        if (! is_checkout()) {
+        if ( ! is_checkout()) {
             return;
         }
 
-        if (! $this->is_available()) {
+        if ( ! $this->is_available()) {
             return;
         }
 
@@ -753,8 +740,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         apply_filters('integrationRedeSetCustomCSSPro', get_option('woocommerce_maxipago_credit_settings')['custom_css_short_code'] ?? false);
     }
 
-    public function getMerchantAuth()
-    {
+    public function getMerchantAuth() {
         $plugin_url = plugin_dir_url(LknIntegrationRedeForWoocommerceWcRede::FILE) . '../';
 
         return array(
@@ -770,3 +756,4 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         ));
     }
 }
+?>

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
@@ -5,10 +5,8 @@ namespace Lkn\IntegrationRedeForWoocommerce\Includes;
 use Exception;
 use WC_Order;
 
-final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrationRedeForWoocommerceWcRedeAbstract
-{
-    public function __construct()
-    {
+final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrationRedeForWoocommerceWcRedeAbstract {
+    public function __construct() {
         $this->id = 'maxipago_debit';
         $this->method_title = esc_attr__('Pay with the Maxipago Debit', 'woo-rede');
         $this->method_description = esc_attr__('Enables and configures payments with Maxipago Debit', 'woo-rede');
@@ -44,8 +42,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
      *
      * @return bool
      */
-    public function validate_fields()
-    {
+    public function validate_fields() {
         if (empty(sanitize_text_field(wp_unslash($_POST['maxipago_debit_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cnpj'])))) {
             wc_add_notice(esc_attr__('CPF is a required field', 'woo-rede'), 'error');
 
@@ -70,7 +67,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             return false;
         }
 
-        if (! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_debit_cvc'])))) {
+        if ( ! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_debit_cvc'])))) {
             wc_add_notice(esc_attr__('Card security code must be a numeric value', 'woo-rede'), 'error');
             return false;
         }
@@ -89,9 +86,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         return true;
     }
 
-    public function addNeighborhoodFieldToCheckout($fields)
-    {
-        if (! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
+    public function addNeighborhoodFieldToCheckout($fields) {
+        if ( ! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
             && $this->is_available()) {
             $fields['billing']['billing_neighborhood'] = array(
                 'label' => __('District', 'woo-rede'),
@@ -117,8 +113,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
      *
      * @return array
      */
-    public function getConfigsMaxipagoDebit()
-    {
+    public function getConfigsMaxipagoDebit() {
         $configs = array();
 
         $configs['basePath'] = INTEGRATION_REDE_FOR_WOOCOMMERCE_DIR . 'Includes/logs/';
@@ -128,8 +123,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         return $configs;
     }
 
-    public function initFormFields(): void
-    {
+    public function initFormFields(): void {
         LknIntegrationRedeForWoocommerceHelper::updateFixLoadScriptOption($this->id);
 
         $this->form_fields = array(
@@ -217,13 +211,12 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
 
         $customConfigs = apply_filters('integrationRedeGetCustomConfigs', $this->form_fields, array(), $this->id);
 
-        if (! empty($customConfigs)) {
+        if ( ! empty($customConfigs)) {
             $this->form_fields = array_merge($this->form_fields, $customConfigs);
         }
     }
 
-    protected function getCheckoutForm($order_total = 0): void
-    {
+    protected function getCheckoutForm($order_total = 0): void {
         wc_get_template(
             'debitCard/maxipagoPaymentDebitForm.php',
             array(),
@@ -232,8 +225,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         );
     }
 
-    public function process_payment($orderId)
-    {
+    public function process_payment($orderId) {
         if (isset($_POST['maxipago_debit_nonce']) && ! wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['maxipago_debit_nonce'])), 'maxipago_debit_nonce')) {
             return array(
                 'result' => 'fail',
@@ -304,7 +296,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
                 throw new Exception(__('One or more invalid fields', 'woo-rede'), 500);
             }
 
-            if (! $this->validateCpfCnpj($clientData['billing_cpf'])) {
+            if ( ! $this->validateCpfCnpj($clientData['billing_cpf'])) {
                 throw new Exception(__("Please enter a valid cpf number", 'woo-rede'));
             }
 
@@ -378,7 +370,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             $xml_encode = wp_json_encode($xml);
             $xml_decode = json_decode($xml_encode, true);
 
-            if ("APPROVED" == $xml_decode['processorMessage']) {
+            if (isset($xml_decode['processorCode']) && "00" == $xml_decode['processorCode']) {
                 $order->update_meta_data('_wc_maxipago_transaction_return_message', $xml_decode['processorMessage']);
                 $order->update_meta_data('_wc_maxipago_transaction_id', $xml_decode['orderID']);
                 $order->update_meta_data('_wc_maxipago_transaction_bin', $xml_decode['creditCardBin']);
@@ -407,7 +399,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
                 throw new Exception($xml_decode['errorMessage']);
             }
             //Caso não exista nenhuma das Message, o Merchant ID ou Merchant Key estão invalidos
-            if (! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
+            if ( ! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
                 throw new Exception(__("Merchant ID or Merchant Key is invalid!", 'woo-rede'));
             }
 
@@ -427,8 +419,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         );
     }
 
-    public function validateCpfCnpj($cpfCnpj)
-    {
+    public function validateCpfCnpj($cpfCnpj) {
         // Remove caracteres especiais
         $cpfCnpj = preg_replace('/[^0-9]/', '', $cpfCnpj);
 
@@ -494,8 +485,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         return false;
     }
 
-    public function displayMeta($order): void
-    {
+    public function displayMeta($order): void {
         if ($order->get_payment_method() === 'maxipago_debit') {
             $metaKeys = array(
                 '_wc_maxipago_transaction_environment' => esc_attr__('Environment', 'woo-rede'),
@@ -514,18 +504,17 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         }
     }
 
-    public function checkoutScripts(): void
-    {
+    public function checkoutScripts(): void {
         $plugin_url = plugin_dir_url(LknIntegrationRedeForWoocommerceWcRede::FILE) . '../';
         if ($this->get_option('enabled_fix_load_script') === 'yes') {
             wp_enqueue_script('fixInfiniteLoading-js', $plugin_url . 'Public/js/fixInfiniteLoading.js', array(), '1.0.0', true);
         }
 
-        if (! is_checkout()) {
+        if ( ! is_checkout()) {
             return;
         }
 
-        if (! $this->is_available()) {
+        if ( ! $this->is_available()) {
             return;
         }
 
@@ -545,3 +534,4 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         apply_filters('integrationRedeSetCustomCSSPro', get_option('woocommerce_maxipago_debit_settings')['custom_css_short_code'] ?? false);
     }
 }
+?>

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
@@ -370,7 +370,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             $xml_encode = wp_json_encode($xml);
             $xml_decode = json_decode($xml_encode, true);
 
-            if (isset($xml_decode['processorCode']) && "00" == $xml_decode['processorCode']) {
+            if (isset($xml_decode['responseCode']) && "0" == $xml_decode['responseCode']) {
                 $order->update_meta_data('_wc_maxipago_transaction_return_message', $xml_decode['processorMessage']);
                 $order->update_meta_data('_wc_maxipago_transaction_id', $xml_decode['orderID']);
                 $order->update_meta_data('_wc_maxipago_transaction_bin', $xml_decode['creditCardBin']);

--- a/Includes/LknIntegrationRedeForWoocommerceWcPixHelper.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcPixHelper.php
@@ -18,7 +18,7 @@ final class LknIntegrationRedeForWoocommerceWcPixHelper
         $date = new DateTime();
         $date->modify('+' . $expirationCount . ' hours');
         $dateTimeExpiration = $date->format('Y-m-d\TH:i:s');
-        $order->update_meta_data('_wc_rede_pix_time_expiration', $dateTimeExpiration);
+        $order->update_meta_data('_wc_rede_pix_integration_time_expiration', $dateTimeExpiration);
         if ('production' === $environment) {
             $apiUrl = 'https://api.userede.com.br/erede/v1/transactions';
         } else {

--- a/Includes/LknIntegrationRedeForWoocommerceWcPixRede.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcPixRede.php
@@ -163,8 +163,8 @@ final class LknIntegrationRedeForWoocommerceWcPixRede extends WC_Payment_Gateway
 
         try {
             $pixInfos = array(
-                'generated' => $order->get_meta('_wc_rede_pix_transaction_pix_generated'),
-                'amount' => $order->get_meta('_wc_rede_pix_transaction_amount'),
+                'generated' => $order->get_meta('_wc_rede_pix_integration_transaction_pix_generated'),
+                'amount' => $order->get_meta('_wc_rede_pix_integration_transaction_amount'),
             );
             $total = str_replace(".", "", $order->get_total());
             if (empty($pixInfos['generated']) || $total != $pixInfos['amount']) {
@@ -194,12 +194,12 @@ final class LknIntegrationRedeForWoocommerceWcPixRede extends WC_Payment_Gateway
                 $pixQrCodeData = $pix['qrCodeResponse']['qrCodeData'];
                 $pixQrCodeImage = $pix['qrCodeResponse']['qrCodeImage'];
 
-                $order->update_meta_data('_wc_rede_pix_transaction_reference', $pixReference);
+                $order->update_meta_data('_wc_rede_pix_integration_transaction_reference', $pixReference);
                 $order->update_meta_data('_wc_rede_integration_pix_transaction_tid', $pixTid);
-                $order->update_meta_data('_wc_rede_pix_transaction_amount', $pixAmount);
-                $order->update_meta_data('_wc_rede_pix_transaction_pix_code', $pixQrCodeData);
-                $order->update_meta_data('_wc_rede_pix_transaction_pix_generated', true);
-                $order->update_meta_data('_wc_rede_pix_transaction_pix_qrcode_base64', $pixQrCodeImage);
+                $order->update_meta_data('_wc_rede_pix_integration_transaction_amount', $pixAmount);
+                $order->update_meta_data('_wc_rede_pix_integration_transaction_pix_code', $pixQrCodeData);
+                $order->update_meta_data('_wc_rede_pix_integration_transaction_pix_generated', true);
+                $order->update_meta_data('_wc_rede_pix_integration_transaction_pix_qrcode_base64', $pixQrCodeImage);
 
                 if ('yes' == $this->debug) {
                     $this->log->log('info', $this->id, array(
@@ -272,7 +272,7 @@ final class LknIntegrationRedeForWoocommerceWcPixRede extends WC_Payment_Gateway
     {
         if ($order->get_payment_method() === 'integration_rede_pix') {
             $metaKeys = array(
-                '_wc_rede_pix_transaction_reference' => esc_attr__('Reference Number', 'woo-rede'),
+                '_wc_rede_pix_integration_transaction_reference' => esc_attr__('Reference Number', 'woo-rede'),
                 '_wc_rede_integration_pix_transaction_tid' => esc_attr__('TID', 'woo-rede'),
             );
 
@@ -285,11 +285,11 @@ final class LknIntegrationRedeForWoocommerceWcPixRede extends WC_Payment_Gateway
         $order = wc_get_order($orderWCID);
 
         if ($order->get_payment_method() == 'integration_rede_pix') {
-            $orderBase64 = $order->get_meta('_wc_rede_pix_transaction_pix_qrcode_base64');
-            $pixCode = $order->get_meta('_wc_rede_pix_transaction_pix_code');
+            $orderBase64 = $order->get_meta('_wc_rede_pix_integration_transaction_pix_qrcode_base64');
+            $pixCode = $order->get_meta('_wc_rede_pix_integration_transaction_pix_code');
             $filePath = INTEGRATION_REDE_FOR_WOOCOMMERCE_DIR_URL . 'Public/images/share.svg';
             $total = wc_price($order->get_total());
-            $timeExpiration = $order->get_meta('_wc_rede_pix_time_expiration');
+            $timeExpiration = $order->get_meta('_wc_rede_pix_integration_time_expiration');
             $dateTime = new DateTime($timeExpiration);
             $formattedDate = 'Vencimento: ' . $dateTime->format('d/m/Y');
             wc_get_template(

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -41,7 +41,10 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
             update_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorCredit', false);
         }
 
-        $this->auto_capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? false : true;
+        $this->auto_capture = true;
+        if (is_plugin_active('rede-for-woocommerce-pro/rede-for-woocommerce-pro.php')) {
+            $this->auto_capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? false : true;
+        }
         $this->max_parcels_number = $this->get_option('max_parcels_number');
         $this->min_parcels_value = $this->get_option('min_parcels_value');
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -41,10 +41,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
             update_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorCredit', false);
         }
 
-        $this->auto_capture = true;
-        if (is_plugin_active('rede-for-woocommerce-pro/rede-for-woocommerce-pro.php')) {
-            $this->auto_capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? false : true;
-        }
+        $this->auto_capture = sanitize_text_field($this->get_option('auto_capture')) == 'no' ? false : true;
         $this->max_parcels_number = $this->get_option('max_parcels_number');
         $this->min_parcels_value = $this->get_option('min_parcels_value');
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -436,6 +436,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
             if ($this->get_option('installment_interest') == 'yes') {
                 $order_total = apply_filters('integrationRedeGetInterest', $order_total, $interest, '', 'total');
             }
+            $order_total = (float) $order_total;
 
             $transaction = $this->api->doTransactionCreditRequest($orderId + time(), $order_total, $installments, $cardData);
             $order->update_meta_data('_transaction_id', $transaction->getTid());

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -327,6 +327,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
 
             $orderId = $order->get_id();
             $amount = $order->get_total();
+            $amount = (float) $amount;
 
             $transaction = $this->api->doTransactionDebitRequest($orderId + time(), $amount, $cardData);
 

--- a/Includes/templates/creditCard/maxipagoPaymentCreditForm.php
+++ b/Includes/templates/creditCard/maxipagoPaymentCreditForm.php
@@ -61,8 +61,8 @@ $selectStyle = '';
         ></div>
         <div class="wc-payment-maxipago-form-fields">
 
-            <?php if (  get_option('wcbcf_settings', ['person_type' => ''])['person_type'] === "0" ||
-                        !is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')) {    ?>
+            <?php if (  get_option('wcbcf_settings', array('person_type' => ''))['person_type'] === "0" ||
+                        ! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')) {    ?>
             <div class="form-row form-row">
                 <label
                     id="labels-with-icons"
@@ -155,9 +155,11 @@ $selectStyle = '';
                     name="maxipago_credit_holder_name"
                     class="input-text"
                     type="text"
-                    placeholder=<?php esc_attr_e( 'Name', 'woo-rede' ); ?>
-                    maxlength="22" autocomplete="off"
-                    style="font-size: 1.5em; padding: 8px 45px;"/>
+                    placeholder="<?php esc_attr_e( 'Name', 'woo-rede' ); ?>"
+                    maxlength="30"
+                    autocomplete="off"
+                    style="font-size: 1.5em; padding: 8px 45px;"
+                />
             </div>
 
             <div class="form-row form-row">

--- a/Includes/templates/creditCard/redePaymentCreditForm.php
+++ b/Includes/templates/creditCard/redePaymentCreditForm.php
@@ -1,5 +1,5 @@
 <?php
-if (! defined('ABSPATH')) {
+if ( ! defined('ABSPATH')) {
     exit();
 }
 $theme = wp_get_theme();
@@ -87,9 +87,11 @@ $selectStyle = '';
                     name="rede_credit_holder_name"
                     class="input-text"
                     type="text"
-                    placeholder=<?php esc_attr_e('Name', 'woo-rede'); ?>
-                maxlength="22" autocomplete="off"
-                style="font-size: 1.5em; padding: 8px 45px;"/>
+                    placeholder="<?php esc_attr_e('Name', 'woo-rede'); ?>"
+                    maxlength="30"
+                    autocomplete="off"
+                    style="font-size: 1.5em; padding: 8px 45px;"
+                />
             </div>
 
             <div class="form-row form-row">

--- a/Includes/templates/debitCard/maxipagoPaymentDebitForm.php
+++ b/Includes/templates/debitCard/maxipagoPaymentDebitForm.php
@@ -19,8 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
             id="maxipagoDebitCardAnimation"
             class="card-wrapper card-animation"
         ></div>
-        <?php if (  get_option('wcbcf_settings', ['person_type' => ''])['person_type'] === "0" ||
-                    !is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')) {    ?>
+        <?php if (  get_option('wcbcf_settings', array('person_type' => ''))['person_type'] === "0" ||
+                    ! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')) {    ?>
 
         <div class="form-row form-row">
             <label
@@ -114,9 +114,10 @@ if ( ! defined( 'ABSPATH' ) ) {
                 name="maxipago_debit_holder_name"
                 class="input-text"
                 type="text"
-                placeholder=<?php esc_attr_e( 'Name', 'woo-rede' ); ?>
-                maxlength="22" autocomplete="off"
-                style="font-size: 1.5em; padding: 8px 45px;"/>
+                placeholder=<i
+            ></i><!-- %pcs-comment-start#<?php esc_attr_e( 'Name', 'woo-rede' ); ?>
+            maxlength="30" autocomplete="off"
+            style="font-size: 1.5em; padding: 8px 45px;"/>
         </div>
 
         <div class="form-row form-row">

--- a/Includes/templates/debitCard/maxipagoPaymentDebitForm.php
+++ b/Includes/templates/debitCard/maxipagoPaymentDebitForm.php
@@ -115,7 +115,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 class="input-text"
                 type="text"
                 placeholder=<i
-            ></i><!-- %pcs-comment-start#<?php esc_attr_e( 'Name', 'woo-rede' ); ?>
+            ></i><?php esc_attr_e( 'Name', 'woo-rede' ); ?>
             maxlength="30" autocomplete="off"
             style="font-size: 1.5em; padding: 8px 45px;"/>
         </div>

--- a/Includes/templates/debitCard/redePaymentDebitForm.php
+++ b/Includes/templates/debitCard/redePaymentDebitForm.php
@@ -33,7 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                     name="rede_debit_holder_name" class="input-text"
                     type="text"
                     placeholder=<?php esc_attr_e( 'Name', 'woo-rede' ); ?>
-                    maxlength="22" autocomplete="off"
+                    maxlength="30" autocomplete="off"
                     style="font-size: 1.5em; padding: 8px 45px;"/>
             </div>
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: woocommerce,payment,card,credit
 Requires at least: 5.0
 Tested up to: 6.7.1
-Stable tag: 3.6.3
+Stable tag: 3.6.4
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -72,6 +72,9 @@ The Integration Rede for WooCommerce plugin is now live and working.
 * Have installed the WooCommerce plugin.
 
 == Changelog ==
+# 3.6.4 - 2025/02/27
+* Add conversion of the total purchase amount.
+
 # 3.6.3 - 2025/02/24
 * Fix settings when the PRO plugin is deactivated.
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: woocommerce,payment,card,credit
 Requires at least: 5.0
 Tested up to: 6.7.1
-Stable tag: 3.6.2
+Stable tag: 3.6.3
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -72,6 +72,9 @@ The Integration Rede for WooCommerce plugin is now live and working.
 * Have installed the WooCommerce plugin.
 
 == Changelog ==
+# 3.6.3 - 2025/02/24
+* Fix settings when the PRO plugin is deactivated.
+
 # 3.6.2 - 2025/02/03
 * Fix CVV field validation.
 

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede for WooCommerce
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           3.6.2
+ * Version:           3.6.3
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/wordpress
  * License:           GPL-3.0+

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede for WooCommerce
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           3.6.3
+ * Version:           3.6.4
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/wordpress
  * License:           GPL-3.0+

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.6.2');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.6.3');
 }
 
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_FILE')) {

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.6.3');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.6.4');
 }
 
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_FILE')) {


### PR DESCRIPTION
- Correção configurações quando o plugin PRO está desativado
> Configurações exclusivas do plugin PRO não influenciam mais o plugin gratuito quando o plugin PRO está desativado.

- Adição de conversão do valor total da compra
> Implementada lógica para forçar o tipo da variável, evitando inconsistências no cálculo do total.
