### PR TITLE
3.6.4 Correção de transações da MaxiPago não reconhecidas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.6.4 - 27/02/2025
-- Adição de conversão do valor total da compra.
+- Adição de conversão do valor total da compra;
+- Correção configurações quando o plugin PRO está desativado.
 
 # 3.6.3 - 24/02/2025
 - Correção configurações quando o plugin PRO está desativado.

--- a/README.txt
+++ b/README.txt
@@ -73,7 +73,8 @@ The Integration Rede for WooCommerce plugin is now live and working.
 
 == Changelog ==
 # 3.6.4 - 2025/02/27
-* Add conversion of the total purchase amount.
+* Add conversion of the total purchase amount;
+* Fix settings when the PRO plugin is deactivated.
 
 # 3.6.3 - 2025/02/24
 * Fix settings when the PRO plugin is deactivated.


### PR DESCRIPTION
- Correção configurações quando o plugin PRO está desativado
> Configurações exclusivas do plugin PRO não influenciam mais o plugin gratuito quando o plugin PRO está desativado.

- Adição de conversão do valor total da compra
> Implementada lógica para forçar o tipo da variável, evitando inconsistências no cálculo do total.
