### PR TITLE
3.7.3 - integration-rede-for-woocommerce (Correção no reembolso de pagamento) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ env:
   PLUGIN_NAME: integration-rede-for-woocommerce
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
+  DEPLOY_TAG: "3.7.3"
 
 jobs:
   release-build:
@@ -17,6 +18,25 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v3
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ env.PHP_VERSION }}
+        coverage: none
+
+    # Plugin check
+    - name: Install PHP_CodeSniffer and WordPress Standards
+      run: |
+        composer global require "squizlabs/php_codesniffer=*"
+        composer global require "wp-coding-standards/wpcs"
+        ~/.composer/vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/wp-coding-standards/wpcs
+        ~/.composer/vendor/bin/phpcs -i
+
+    - name: Run PHPCS with custom ruleset
+      run: |
+        export PATH="$HOME/.composer/vendor/bin:$PATH"
+        phpcs --warning-severity=0
 
     - name: Run composer install
       uses: php-actions/composer@v6
@@ -28,18 +48,38 @@ jobs:
         dev: no
 
     # Add plugin files to a root directory
-    - name: Make plugin root directory
-      run: "mkdir ${{env.DIR_NAME}} && mv -t ./${{env.DIR_NAME}} ./Admin ./Includes ./languages ./Public *.txt *.php *.json && cp -r ./vendor ./${{env.DIR_NAME}}/vendor && find ./${{env.DIR_NAME}} -type f -exec chmod 0644 {} + && find ./${{env.DIR_NAME}} -type d -exec chmod 0755 {} +  && ls -lah"
+    - name: Prepare plugin folder
+      run: |
+        mkdir -p dist
+        mkdir -p build/${{ env.PLUGIN_NAME }}
+        mv ./Admin ./Includes ./languages ./Public *.php *.txt ./build/${{ env.PLUGIN_NAME }}
+        cp -r vendor ./build/${{ env.PLUGIN_NAME }}/vendor
+        find ./build -type f -exec chmod 0644 {} +
+        find ./build -type d -exec chmod 0755 {} +
 
     # Compact plugin as .zip
     - name: Archive Release
       uses: thedoctor0/zip-release@master
       with:
         type: 'zip'
-        path: '${{ env.DIR_NAME }}'
-        directory: '.'
-        filename: '${{ env.DIR_NAME }}.zip'
+        path: '.'
+        directory: 'build'
+        filename: '${{ env.PLUGIN_NAME }}.zip'
         exclusions: '*.git* /*node_modules/* .editorconfig'
+
+    - name: Move .zip to custom location
+      run: |
+        mv ./build/${{ env.PLUGIN_NAME }}.zip ./dist/
+
+    - name: Deploy para WordPress.org
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      env:
+        VERSION: ${{ env.DEPLOY_TAG }}
+        SLUG: woo-rede
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        ASSETS_DIR: .wordpress-org
+        BUILD_DIR: build/${{ env.PLUGIN_NAME }}
 
     # Update version tag
     - name: Bump version and push tag
@@ -47,13 +87,13 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "3.7.3"
+        custom_tag: ${{ env.DEPLOY_TAG }}
 
     # Generate new release
     - name: Generate new Release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "${{ env.DIR_NAME }}.zip"
+        artifacts: "dist/${{ env.PLUGIN_NAME }}.zip"
         token: ${{ secrets.GITHUB_TOKEN }}
         commit: "main"
         draft: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "3.7.2"
+        custom_tag: "3.7.3"
 
     # Generate new release
     - name: Generate new Release

--- a/Admin/LknIntegrationRedeForWoocommerceAdmin.php
+++ b/Admin/LknIntegrationRedeForWoocommerceAdmin.php
@@ -167,6 +167,7 @@ final class LknIntegrationRedeForWoocommerceAdmin
         }
 
         if ('wc-settings' === $page && 'checkout' === $tab && in_array($section, $gateways, true)) {
+            wp_enqueue_script('lknIntegrationRedeForWoocommerceAdminClearLogsButton', plugin_dir_url(__FILE__) . 'js/lkn-integration-rede-for-woocommerce-admin-clear-logs-button.js', array('jquery'), $this->version, false);
             wp_enqueue_script('lknIntegrationRedeForWoocommerceSettingsLayoutScript', plugin_dir_url(__FILE__) . 'js/lkn-integration-rede-for-woocommerce-settings-layout.js', array('jquery'), $this->version, false);
             wp_enqueue_script('lknIntegrationRedeForWoocommerceCard', plugin_dir_url(__FILE__) . 'js/lkn-integration-rede-for-woocommerce-admin-card.js', array('jquery'), $this->version, false);
             wc_get_template(
@@ -184,6 +185,10 @@ final class LknIntegrationRedeForWoocommerceAdmin
                 'woocommerce/adminSettingsCard/',
                 plugin_dir_path(__FILE__) . '../Includes/templates/'
             );
+            wp_localize_script('lknIntegrationRedeForWoocommerceAdminClearLogsButton', 'lknWcRedeTranslations', array(
+                'clearLogs' => __('Limpar Logs', 'woo-rede'),
+                'alertText' => __('Deseja realmente deletar todos logs dos pedidos?', 'woo-rede')
+            ));
         }
 
         // Localize the script with custom data

--- a/Admin/css/lkn-integration-rede-for-woocommerce-admin.css
+++ b/Admin/css/lkn-integration-rede-for-woocommerce-admin.css
@@ -192,6 +192,45 @@ textarea:disabled {
     align-items: center;
 }
 
+#woocommerce_maxipago_debit_clear_order_records{
+    display: flex;
+    justify-content: center;
+    width: fit-content;
+    padding: 0px 20px 0px 20px;
+}
+
+#lknWcRedeOrderLogs pre {
+    padding: 5px;
+    background-color: #D9D9D9;
+    width: fit-content;
+    border-radius: 4px;
+    margin: 0;
+    white-space: pre-wrap
+}
+
+#lknWcRedeOrderLogs pre{
+    padding: 10px;
+    background-color: #D9D9D9 !important;
+    width: fit-content;
+    max-width: 96%;
+    border-radius: 4px;
+    margin: 0;
+    white-space: pre-wrap;
+    overflow-x: auto;
+}
+
+#lknWcRedeOrderLogs h3{
+    color: #333;
+    font-size: 14px;
+    font-weight: bold;
+}
+
+#lknWcRedeOrderLogs div{
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
 @media (max-width: 1205px) {
     #lknIntegrationRedeForWoocommerceSettingsCardTable {
         flex-direction: column;

--- a/Admin/js/lkn-integration-rede-for-woocommerce-admin-clear-logs-button.js
+++ b/Admin/js/lkn-integration-rede-for-woocommerce-admin-clear-logs-button.js
@@ -1,0 +1,59 @@
+const lknWcRedeUrlParams = new URLSearchParams(window.location.search)
+const lknWcRedeSection = lknWcRedeUrlParams.get('section')
+// Dom loaded
+
+// Dom carregado
+
+document.addEventListener('DOMContentLoaded', function () { 
+  const lknWcRedeValidateButton = document.querySelector(`#woocommerce_${lknWcRedeSection}_clear_order_records`)
+  const lknWcRedeShowOrderLogs = document.querySelector(`#woocommerce_${lknWcRedeSection}_show_order_logs`)
+  const lknWcRedeDebug = document.querySelector(`#woocommerce_${lknWcRedeSection}_debug`)
+
+  function changeShowOrderLogs() {
+    if(!lknWcRedeDebug.checked) {
+      lknWcRedeShowOrderLogs.checked = false
+      lknWcRedeShowOrderLogs.disabled = true
+    }
+    else{
+      lknWcRedeShowOrderLogs.disabled = false
+    }
+  }
+
+  if(lknWcRedeDebug && lknWcRedeShowOrderLogs) {
+    changeShowOrderLogs()
+    lknWcRedeDebug.onchange = () => {
+      changeShowOrderLogs()
+    }
+  }
+
+
+  const lknWcRedeForValidateButton = document.querySelector(`label[for="woocommerce_${lknWcRedeSection}_clear_order_records"]`)
+  if (lknWcRedeForValidateButton) {
+    lknWcRedeForValidateButton.removeAttribute('for')
+  }
+
+  if (lknWcRedeValidateButton) {
+    lknWcRedeValidateButton.value = lknWcRedeTranslations.clearLogs
+    lknWcRedeValidateButton.addEventListener('click', function () {
+      lknWcRedeValidateButton.disabled = true
+      lknWcRedeValidateButton.className = lknWcRedeValidateButton.className + ' is-busy'
+
+      if (confirm(lknWcRedeTranslations.alertText)) {
+        jQuery.ajax({
+          type: 'DELETE',
+          url: wpApiSettings.root + 'redeIntegration/clearOrderLogs',
+          contentType: 'application/json',
+          success: function (status) {
+            lknWcRedeValidateButton.disabled = false
+            location.reload()
+          },
+          error: function (error) {
+            console.error(error)
+            lknWcRedeValidateButton.disabled = false
+            lknWcRedeValidateButton.className = lknWcRedeValidateButton.className.replace(' is-busy', '')
+          }
+        })
+      }
+    })
+  }
+})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.7.3 - 05/05/2025
+- Correção no reembolso de pagamento.
+
 # 3.7.2 - 08/04/2025
 - Atualização de "Tested up to" para a versão mais recente do WordPress.
 

--- a/Includes/LknIntegrationRedeForWoocommerce.php
+++ b/Includes/LknIntegrationRedeForWoocommerce.php
@@ -159,12 +159,12 @@ final class LknIntegrationRedeForWoocommerce
         $this->loader->add_filter('plugin_action_links_' . INTEGRATION_REDE_FOR_WOOCOMMERCE_BASENAME, $this, 'addSettings');
 
         $this->loader->add_action('woocommerce_order_status_cancelled', $this->wc_rede_credit_class, 'process_refund');
+
         $this->loader->add_action('woocommerce_update_options_payment_gateways_' . $this->wc_rede_credit_class->id, $this->wc_rede_credit_class, 'process_admin_options');
         $this->loader->add_action('woocommerce_api_wc_rede_credit', $this->wc_rede_credit_class, 'check_return');
         $this->loader->add_filter('woocommerce_get_order_item_totals', $this->wc_rede_credit_class, 'order_items_payment_details', 10, 2);
         $this->loader->add_action('woocommerce_admin_order_data_after_billing_address', $this->wc_rede_credit_class, 'displayMeta', 10, 1);
 
-        $this->loader->add_action('woocommerce_order_status_cancelled', $this->wc_rede_debit_class, 'process_refund');
         $this->loader->add_action('woocommerce_update_options_payment_gateways_' . $this->wc_rede_debit_class->id, $this->wc_rede_debit_class, 'process_admin_options');
         $this->loader->add_action('woocommerce_api_wc_rede_credit', $this->wc_rede_debit_class, 'check_return');
         $this->loader->add_filter('woocommerce_get_order_item_totals', $this->wc_rede_debit_class, 'order_items_payment_details', 10, 2);

--- a/Includes/LknIntegrationRedeForWoocommerceHelper.php
+++ b/Includes/LknIntegrationRedeForWoocommerceHelper.php
@@ -62,4 +62,22 @@ abstract class LknIntegrationRedeForWoocommerceHelper
 
         return($response_body['authorization']['brand']['name']);
     }
+
+    final public static function censorString($string, $censorLength) {
+        $length = strlen($string);
+
+        if ($censorLength >= $length) {
+            // Se o número de caracteres a censurar for maior ou igual ao comprimento total, censura tudo
+            return str_repeat('*', $length);
+        }
+
+        $startLength = floor(($length - $censorLength) / 2); // Dividir o restante igualmente entre início e fim
+        $endLength = $length - $startLength - $censorLength; // O que sobra para o final
+
+        $start = substr($string, 0, $startLength);
+        $end = substr($string, -$endLength);
+
+        $censored = str_repeat('*', $censorLength);
+        return $start . $censored . $end;
+    }
 }

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -26,6 +26,29 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
             'callback' => array($this, 'maxipagoDebitListener'),
             'permission_callback' => '__return_true',
         ));
+
+        register_rest_route('redeIntegration', '/clearOrderLogs', array(
+            'methods' => 'DELETE',
+            'callback' => array($this, 'clearOrderLogs'),
+            'permission_callback' => '__return_true',
+        ));
+    }
+
+    public function clearOrderLogs($request) {
+        $args = array(
+            'limit' => -1, // Sem limite, pega todas as ordens
+            'meta_key' => 'lknWcRedeOrderLogs', // Meta key específica
+            'meta_compare' => 'EXISTS', // Verifica se a meta key existe
+        );
+
+        $orders = wc_get_orders($args);
+
+        foreach ($orders as $order) {
+            $order->delete_meta_data('lknWcRedeOrderLogs');
+            $order->save();
+        }
+
+        return new WP_REST_Response($orders, 200);
     }
 
     public function maxipagoDebitListener($request) {

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
@@ -6,8 +6,10 @@ use Exception;
 use WC_Order;
 use WP_Error;
 
-final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrationRedeForWoocommerceWcRedeAbstract {
-    public function __construct() {
+final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrationRedeForWoocommerceWcRedeAbstract
+{
+    public function __construct()
+    {
         $this->id = 'maxipago_credit';
         $this->method_title = esc_attr__('Pay with the Maxipago Credit', 'woo-rede');
         $this->method_description = esc_attr__('Enables and configures payments with Maxipago Credit', 'woo-rede');
@@ -45,7 +47,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
      *
      * @return bool
      */
-    public function validate_fields() {
+    public function validate_fields()
+    {
         if (empty(sanitize_text_field(wp_unslash($_POST['maxipago_credit_card_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cnpj'])))) {
             wc_add_notice(esc_attr__('CPF is a required field', 'woo-rede'), 'error');
 
@@ -70,7 +73,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             return false;
         }
 
-        if ( ! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_credit_cvc'])))) {
+        if (! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_credit_cvc'])))) {
             wc_add_notice(esc_attr__('Card security code must be a numeric value', 'woo-rede'), 'error');
             return false;
         }
@@ -89,8 +92,9 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return true;
     }
 
-    public function addNeighborhoodFieldToCheckout($fields) {
-        if ( ! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
+    public function addNeighborhoodFieldToCheckout($fields)
+    {
+        if (! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
             && $this->is_available()) {
             $fields['billing']['billing_neighborhood'] = array(
                 'label' => __('District', 'woo-rede'),
@@ -116,7 +120,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
      *
      * @return array
      */
-    public function getConfigsMaxipagoCredit() {
+    public function getConfigsMaxipagoCredit()
+    {
         $configs = array();
 
         $configs['basePath'] = INTEGRATION_REDE_FOR_WOOCOMMERCE_DIR . 'Includes/logs/';
@@ -126,7 +131,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return $configs;
     }
 
-    public function initFormFields(): void {
+    public function initFormFields(): void
+    {
         LknIntegrationRedeForWoocommerceHelper::updateFixLoadScriptOption($this->id);
 
         $this->form_fields = array(
@@ -251,12 +257,13 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             'max_parcels_number' => $this->get_option('max_parcels_number'),
         ), $this->id);
 
-        if ( ! empty($customConfigs)) {
+        if (! empty($customConfigs)) {
             $this->form_fields = array_merge($this->form_fields, $customConfigs);
         }
     }
 
-    protected function getCheckoutForm($order_total = 0): void {
+    protected function getCheckoutForm($order_total = 0): void
+    {
         wc_get_template(
             'creditCard/maxipagoPaymentCreditForm.php',
             array(
@@ -267,7 +274,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         );
     }
 
-    public function getInstallments($order_total = 0) {
+    public function getInstallments($order_total = 0)
+    {
         $installments = array();
         $customLabel = null;
         $defaults = array(
@@ -303,7 +311,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return $installments;
     }
 
-    public function process_payment($orderId) {
+    public function process_payment($orderId)
+    {
         if (isset($_POST['maxipago_card_nonce']) && ! wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['maxipago_card_nonce'])), 'maxipagoCardNonce')) {
             return array(
                 'result' => 'fail',
@@ -391,7 +400,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
                 throw new Exception(__('Invalid number of installments', 'woo-rede'));
             }
 
-            if ( ! $this->validateCpfCnpj($clientData['billing_cpf'])) {
+            if (! $this->validateCpfCnpj($clientData['billing_cpf'])) {
                 throw new Exception(__("Please enter a valid cpf number", 'woo-rede'));
             }
             if ('production' === $environment) {
@@ -491,7 +500,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
                     $order->update_meta_data('_wc_rede_captured', false);
                     $order->update_status('on-hold');
                 }
-            }elseif(isset($xml_decode['responseCode']) && "1" == $xml_decode['responseCode']){
+            } elseif (isset($xml_decode['responseCode']) && "1" == $xml_decode['responseCode']) {
                 throw new Exception($xml_decode['processorMessage']);
             }
             if ('yes' == $this->debug) {
@@ -511,7 +520,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
                 throw new Exception($xml_decode['errorMessage']);
             }
             //Caso não exista nenhuma das Message, o Merchant ID ou Merchant Key estão invalidos
-            if ( ! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
+            if (! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
                 throw new Exception(__("Merchant ID or Merchant Key is invalid!", 'woo-rede'));
             }
 
@@ -531,7 +540,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         );
     }
 
-    public function process_refund($order_id, $amount = null, $reason = '') {
+    public function process_refund($order_id, $amount = null, $reason = '')
+    {
         $order = new WC_Order($order_id);
         $totalAmount = $order->get_meta('_wc_maxipago_total_amount');
         $environment = $this->get_option('environment');
@@ -625,7 +635,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return false;
     }
 
-    public function validateCpfCnpj($cpfCnpj) {
+    public function validateCpfCnpj($cpfCnpj)
+    {
         // Remove caracteres especiais
         $cpfCnpj = preg_replace('/[^0-9]/', '', $cpfCnpj);
 
@@ -691,7 +702,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         return false;
     }
 
-    public function displayMeta($order): void {
+    public function displayMeta($order): void
+    {
         if ($order->get_payment_method() === 'maxipago_credit') {
             $metaKeys = array(
                 '_wc_maxipago_transaction_environment' => esc_attr__('Environment', 'woo-rede'),
@@ -711,17 +723,18 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         }
     }
 
-    public function checkoutScripts(): void {
+    public function checkoutScripts(): void
+    {
         $plugin_url = plugin_dir_url(LknIntegrationRedeForWoocommerceWcRede::FILE) . '../';
         if ($this->get_option('enabled_fix_load_script') === 'yes') {
             wp_enqueue_script('fixInfiniteLoading-js', $plugin_url . 'Public/js/fixInfiniteLoading.js', array(), '1.0.0', true);
         }
 
-        if ( ! is_checkout()) {
+        if (! is_checkout()) {
             return;
         }
 
-        if ( ! $this->is_available()) {
+        if (! $this->is_available()) {
             return;
         }
 
@@ -741,7 +754,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         apply_filters('integrationRedeSetCustomCSSPro', get_option('woocommerce_maxipago_credit_settings')['custom_css_short_code'] ?? false);
     }
 
-    public function getMerchantAuth() {
+    public function getMerchantAuth()
+    {
         $plugin_url = plugin_dir_url(LknIntegrationRedeForWoocommerceWcRede::FILE) . '../';
 
         return array(
@@ -757,4 +771,3 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
         ));
     }
 }
-?>

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
@@ -280,7 +280,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         $merchantId = sanitize_text_field($this->get_option('merchant_id'));
         $merchantKey = sanitize_text_field($this->get_option('merchant_key'));
         $referenceNum = uniqid('order_', true);
-        $browser = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
+        $browser = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
 
         $creditExpiry = isset($_POST['maxipago_debit_expiry']) ? sanitize_text_field(wp_unslash($_POST['maxipago_debit_expiry'])) : '';
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
@@ -231,6 +231,21 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             )
         );
 
+        if ($this->get_option('debug') == 'yes') {
+            $this->form_fields['show_order_logs'] =  array(
+                'title' => __('Visualizar Log no Pedido', 'woo-rede'),
+                'type' => 'checkbox',
+                'label' => sprintf('Habilita visualização do log da transação dentro do pedido.', 'woo-rede'),
+                'default' => 'no',
+            );
+            $this->form_fields['clear_order_records'] =  array(
+                'title' => __('Limpar logs nos Pedidos', 'woo-rede'),
+                'type' => 'button',
+                'id' => 'validateLicense',
+                'class' => 'woocommerce-save-button components-button is-primary'
+            );
+        }
+
         $customConfigs = apply_filters('integrationRedeGetCustomConfigs', $this->form_fields, array(), $this->id);
 
         if ( ! empty($customConfigs)) {
@@ -414,6 +429,36 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             //Reconstruindo o $xml para facilitar o uso da variavel
             $xml_encode = wp_json_encode($xml);
             $xml_decode = json_decode($xml_encode, true);
+            if ('yes' == $this->debug) {
+                $this->log->log('info', $this->id, array(
+                    'request' => simplexml_load_string($xmlData),
+                    'response' => $xml,
+                    'order' => array(
+                        'orderId' => $orderId,
+                        'amount' => $order->get_total(),
+                        'status' => $order->get_status()
+                    ),
+                ));
+                
+                
+                $xmlBody = simplexml_load_string($xmlData);
+                $cardNumber = $xmlBody->order->debitSale->transactionDetail->payType->debitCard->number;
+                
+                $xmlBody->verification->merchantId = LknIntegrationRedeForWoocommerceHelper::censorString($xmlBody->verification->merchantId, 3);
+                $xmlBody->verification->merchantKey = LknIntegrationRedeForWoocommerceHelper::censorString($xmlBody->verification->merchantKey, 12);
+                $xmlBody->order->debitSale->transactionDetail->payType->debitCard->number = LknIntegrationRedeForWoocommerceHelper::censorString($cardNumber, 8);
+                
+                $orderLogsArray = array(
+                    'url' => $apiUrl,
+                    'body' => $xmlBody,
+                    'response' => $xml
+                );
+                
+                $orderLogs = json_encode($orderLogsArray);
+                $order->update_meta_data('lknWcRedeOrderLogs', $orderLogs);
+            }
+            throw new Exception(json_encode($orderLogsArray));
+
 
             if (isset($xml_decode['responseCode']) && "0" == $xml_decode['responseCode']) {
                 $order->update_meta_data('_wc_maxipago_transaction_return_message', $xml_decode['processorMessage']);
@@ -431,17 +476,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             }elseif(isset($xml_decode['responseCode']) && "1" == $xml_decode['responseCode']){
                 throw new Exception($xml_decode['processorMessage']);
             }
-            if ('yes' == $this->debug) {
-                $this->log->log('info', $this->id, array(
-                    'request' => simplexml_load_string($xmlData),
-                    'response' => $xml,
-                    'order' => array(
-                        'orderId' => $orderId,
-                        'amount' => $order->get_total(),
-                        'status' => $order->get_status()
-                    ),
-                ));
-            }
+            
 
             if ("INVALID REQUEST" == $xml_decode['responseMessage']) {
                 throw new Exception($xml_decode['errorMessage']);

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeAPI.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeAPI.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Lkn\IntegrationRedeForWoocommerce\Includes;
 
 use Exception;
@@ -7,7 +8,8 @@ use Rede\Store;
 use Rede\Transaction;
 use Rede\eRede;
 
-final class LknIntegrationRedeForWoocommerceWcRedeAPI {
+final class LknIntegrationRedeForWoocommerceWcRedeAPI
+{
     protected $gateway;
     private $environment;
     private $store;
@@ -16,11 +18,12 @@ final class LknIntegrationRedeForWoocommerceWcRedeAPI {
     private $partner_module;
     private $partner_gateway;
 
-    public function __construct( $gateway = null ) {
+    public function __construct($gateway = null)
+    {
         $pv = $gateway->pv;
         $token = $gateway->token;
 
-        if ( 'test' == $gateway->environment ) {
+        if ('test' == $gateway->environment) {
             $environment = Environment::sandbox();
         } else {
             $environment = Environment::production();
@@ -31,7 +34,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeAPI {
         $this->soft_descriptor = $gateway->soft_descriptor;
         $this->partner_gateway = $gateway->partner_gateway;
         $this->partner_module = $gateway->partner_module;
-        $this->store = new Store( $pv, $token, $environment );
+        $this->store = new Store($pv, $token, $environment);
     }
 
     /**
@@ -47,27 +50,27 @@ final class LknIntegrationRedeForWoocommerceWcRedeAPI {
         $installments = 1,
         $credit_card_data = array()
     ) {
-        $transaction = ( new Transaction( $amount, $id ) )->creditCard(
+        $transaction = (new Transaction($amount, $id))->creditCard(
             $credit_card_data['card_number'],
             $credit_card_data['card_cvv'],
             $credit_card_data['card_expiration_month'],
             $credit_card_data['card_expiration_year'],
             $credit_card_data['card_holder']
-        )->capture( $this->capture );
+        )->capture($this->capture);
 
-        if ( $installments > 1 ) {
-            $transaction->setInstallments( $installments );
+        if ($installments > 1) {
+            $transaction->setInstallments($installments);
         }
 
-        if ( ! empty( $this->soft_descriptor ) ) {
-            $transaction->setSoftDescriptor( $this->soft_descriptor );
+        if (! empty($this->soft_descriptor)) {
+            $transaction->setSoftDescriptor($this->soft_descriptor);
         }
 
-        if ( ! empty( $this->partner_module ) && ! empty( $this->partner_gateway ) ) {
-            $transaction->additional( $this->partner_gateway, $this->partner_module );
+        if (! empty($this->partner_module) && ! empty($this->partner_gateway)) {
+            $transaction->additional($this->partner_gateway, $this->partner_module);
         }
 
-        $transaction = ( new eRede( $this->store, $this->get_logger() ) )->create( $transaction );
+        $transaction = (new eRede($this->store, $this->get_logger()))->create($transaction);
 
         return $transaction;
     }
@@ -84,51 +87,55 @@ final class LknIntegrationRedeForWoocommerceWcRedeAPI {
         $amount,
         $credit_card_data = array()
     ) {
-        $transaction = ( new Transaction( $amount, $id ) )->debitCard(
+        $transaction = (new Transaction($amount, $id))->debitCard(
             $credit_card_data['card_number'],
             $credit_card_data['card_cvv'],
             $credit_card_data['card_expiration_month'],
             $credit_card_data['card_expiration_year'],
             $credit_card_data['card_holder']
-        )->capture( $this->capture );
+        )->capture($this->capture);
 
-        if ( ! empty( $this->soft_descriptor ) ) {
-            $transaction->setSoftDescriptor( $this->soft_descriptor );
+        if (! empty($this->soft_descriptor)) {
+            $transaction->setSoftDescriptor($this->soft_descriptor);
         }
 
-        if ( ! empty( $this->partner_module ) && ! empty( $this->partner_gateway ) ) {
-            $transaction->additional( $this->partner_gateway, $this->partner_module );
+        if (! empty($this->partner_module) && ! empty($this->partner_gateway)) {
+            $transaction->additional($this->partner_gateway, $this->partner_module);
         }
 
-        $transaction = ( new eRede( $this->store, $this->get_logger() ) )->create( $transaction );
+        $transaction = (new eRede($this->store, $this->get_logger()))->create($transaction);
 
         return $transaction;
     }
 
-    protected function get_logger() {
-        $logger = new \Monolog\Logger( 'rede' );
-        $logger->pushHandler( new \Monolog\Handler\StreamHandler( WP_CONTENT_DIR . '/uploads/wc-logs/rede.log', \Monolog\Logger::DEBUG ) );
-        $logger->info( 'Log Rede' );
+    protected function get_logger()
+    {
+        $logger = new \Monolog\Logger('rede');
+        $logger->pushHandler(new \Monolog\Handler\StreamHandler(WP_CONTENT_DIR . '/uploads/wc-logs/rede.log', \Monolog\Logger::DEBUG));
+        $logger->info('Log Rede');
 
         return $logger;
     }
 
-    public function do_transaction_consultation( $tid ) {
-        return ( new eRede( $this->store, $this->get_logger() ) )->get( $tid );
+    public function do_transaction_consultation($tid)
+    {
+        return (new eRede($this->store, $this->get_logger()))->get($tid);
     }
 
-    public function do_transaction_cancellation( $tid, $amount = 0 ) {
-        $transaction = ( new eRede( $this->store, $this->get_logger() ) )->cancel( ( new Transaction( $amount ) )->setTid( $tid ) );
+    public function do_transaction_cancellation($tid, $amount = 0)
+    {
+        $transaction = (new eRede($this->store, $this->get_logger()))->cancel((new Transaction($amount))->setTid($tid));
 
         return $transaction;
     }
 
-    public function do_transaction_capture( $params ) {
+    public function do_transaction_capture($params)
+    {
         $tid = $params['tid'];
         $amount = $params['amount'];
 
         try {
-            $transaction = ( new eRede( $this->store, $this->get_logger() ) )->capture( ( new Transaction( $amount ) )->setTid( $tid ) );
+            $transaction = (new eRede($this->store, $this->get_logger()))->capture((new Transaction($amount))->setTid($tid));
         } catch (\Throwable $th) {
             return $th->getMessage();
         }

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -544,7 +544,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
                     }
                     update_post_meta($order_id, '_wc_rede_transaction_canceled', true);
 
-                    $order->add_order_note(esc_attr__('Transation refund id: ', 'woo-rede') . $transaction->getRefundId());
+                    $order->add_order_note(esc_attr__('Rede Transation refund id: ', 'woo-rede') . $transaction->getRefundId());
                     $order->add_order_note(esc_attr__('Refunded: ', 'woo-rede') . wc_price($amount));
                 } else {
                     $amount = $totalAmount;

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: woocommerce,payment,card,credit
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 3.7.2
+Stable tag: 3.7.3
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -72,6 +72,9 @@ The Integration Rede for WooCommerce plugin is now live and working.
 * Have installed the WooCommerce plugin.
 
 == Changelog ==
+# 3.7.3 - 2025/05/05
+* Fix Correction in payment refund
+
 # 3.7.2 - 2025/04/08
 * Update "Tested up to" to the latest WordPress version.
 

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede for WooCommerce
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           3.7.2
+ * Version:           3.7.3
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/wordpress
  * License:           GPL-3.0+

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.7.2');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '3.7.3');
 }
 
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_FILE')) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset name="Custom WP Standards">
+  <description>Custom WP Coding Standards excluding TextDomainMismatch and warnings</description>
+
+  <rule ref="WordPress-Core" />
+  <rule ref="WordPress-Extra" />
+  <rule ref="WordPress-Docs" />
+
+  <!-- Exclude this specific error -->
+  <exclude name="WordPress.WP.I18n.TextDomainMismatch" />
+
+  <file>./</file>
+</ruleset>


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: rede, payment, credit, debit, pix

Testado até: 6.7.1

Versão estável: 3.7.3

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.

## Descrição

Integre Rede ou Maxipago à sua loja WooCommerce e habilite seus clientes a pagarem com cartão de crédito ou débito.

A [Rede](https://www.userede.com.br/) faz parte do grupo Itaú Unibanco e é uma adquirente responsável pela captura, transmissão e liquidação financeira de transações com cartões de crédito das bandeiras Visa, Mastercard, Elo, American Express, Hipercard, Hyper, Diners Club International, Cabal, Discover, China Union Pay, Aura, Sorocred, Coopercred, Sicredi, Mais!, Calcard, Banescard, Avista! no território brasileiro.

O [Maxipago](https://www.userede.com.br/n/gateway-de-pagamento-rede), que também faz parte do grupo Rede, fornece uma plataforma de gateway de pagamento segura e eficiente para empresas aceitarem os principais cartões de crédito e débito no Brasil. Com segurança avançada e prevenção de fraudes, ele garante a segurança das transações e a confiança do cliente, oferecendo integração simples e suporte para empresas de todos os tamanhos.
## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Resumo(3.7.3):

> Correção durante o mudanças de status para reembolso ou cancelamento do pedido: 

![image](https://github.com/user-attachments/assets/727f3e14-3a09-4a95-9b3d-936ef2aaf302)

![image](https://github.com/user-attachments/assets/1c31eb8c-5dfd-4df4-9715-6e25149a10f2)


