### PR TITLE
3.7.3 - integration-rede-for-woocommerce (Correção no reembolso de pagamento)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,15 @@ jobs:
       with:
         build-dir: './'
         exclude-directories: 'node_modules,vendor,.eslintrc'
-        exclude-checks: 'i18n_usage,direct_db_queries,plugin_readme,file_type'
+        ignore-codes: |
+          WordPress.WP.I18n.TextDomainMismatch
+          WordPress.Security.NonceVerification.Missing
+          WordPress.Security.NonceVerification.Recommended
+          WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+          WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+          trademarked_term
+          textdomain_mismatch
+          hidden_files
         categories: |
           performance
           accessibility

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
@@ -5,8 +5,10 @@ namespace Lkn\IntegrationRedeForWoocommerce\Includes;
 use Exception;
 use WC_Order;
 
-final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrationRedeForWoocommerceWcRedeAbstract {
-    public function __construct() {
+final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrationRedeForWoocommerceWcRedeAbstract
+{
+    public function __construct()
+    {
         $this->id = 'maxipago_debit';
         $this->method_title = esc_attr__('Pay with the Maxipago Debit', 'woo-rede');
         $this->method_description = esc_attr__('Enables and configures payments with Maxipago Debit', 'woo-rede');
@@ -42,7 +44,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
      *
      * @return bool
      */
-    public function validate_fields() {
+    public function validate_fields()
+    {
         if (empty(sanitize_text_field(wp_unslash($_POST['maxipago_debit_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cpf']))) && empty(sanitize_text_field(wp_unslash($_POST['billing_cnpj'])))) {
             wc_add_notice(esc_attr__('CPF is a required field', 'woo-rede'), 'error');
 
@@ -67,7 +70,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             return false;
         }
 
-        if ( ! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_debit_cvc'])))) {
+        if (! ctype_digit(sanitize_text_field(wp_unslash($_POST['maxipago_debit_cvc'])))) {
             wc_add_notice(esc_attr__('Card security code must be a numeric value', 'woo-rede'), 'error');
             return false;
         }
@@ -86,8 +89,9 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         return true;
     }
 
-    public function addNeighborhoodFieldToCheckout($fields) {
-        if ( ! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
+    public function addNeighborhoodFieldToCheckout($fields)
+    {
+        if (! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')
             && $this->is_available()) {
             $fields['billing']['billing_neighborhood'] = array(
                 'label' => __('District', 'woo-rede'),
@@ -113,7 +117,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
      *
      * @return array
      */
-    public function getConfigsMaxipagoDebit() {
+    public function getConfigsMaxipagoDebit()
+    {
         $configs = array();
 
         $configs['basePath'] = INTEGRATION_REDE_FOR_WOOCOMMERCE_DIR . 'Includes/logs/';
@@ -123,7 +128,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         return $configs;
     }
 
-    public function initFormFields(): void {
+    public function initFormFields(): void
+    {
         LknIntegrationRedeForWoocommerceHelper::updateFixLoadScriptOption($this->id);
 
         wp_enqueue_script(
@@ -248,12 +254,13 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
 
         $customConfigs = apply_filters('integrationRedeGetCustomConfigs', $this->form_fields, array(), $this->id);
 
-        if ( ! empty($customConfigs)) {
+        if (! empty($customConfigs)) {
             $this->form_fields = array_merge($this->form_fields, $customConfigs);
         }
     }
 
-    protected function getCheckoutForm($order_total = 0): void {
+    protected function getCheckoutForm($order_total = 0): void
+    {
         wc_get_template(
             'debitCard/maxipagoPaymentDebitForm.php',
             array(),
@@ -262,7 +269,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         );
     }
 
-    public function process_payment($orderId) {
+    public function process_payment($orderId)
+    {
         if (isset($_POST['maxipago_debit_nonce']) && ! wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['maxipago_debit_nonce'])), 'maxipago_debit_nonce')) {
             return array(
                 'result' => 'fail',
@@ -280,7 +288,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         $merchantId = sanitize_text_field($this->get_option('merchant_id'));
         $merchantKey = sanitize_text_field($this->get_option('merchant_key'));
         $referenceNum = uniqid('order_', true);
-        $browser = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '';
+        $browser = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
         $creditExpiry = isset($_POST['maxipago_debit_expiry']) ? sanitize_text_field(wp_unslash($_POST['maxipago_debit_expiry'])) : '';
 
@@ -333,7 +341,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
                 throw new Exception(__('One or more invalid fields', 'woo-rede'), 500);
             }
 
-            if ( ! $this->validateCpfCnpj($clientData['billing_cpf'])) {
+            if (! $this->validateCpfCnpj($clientData['billing_cpf'])) {
                 throw new Exception(__("Please enter a valid cpf number", 'woo-rede'));
             }
 
@@ -439,21 +447,21 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
                         'status' => $order->get_status()
                     ),
                 ));
-                
-                
+
+
                 $xmlBody = simplexml_load_string($xmlData);
                 $cardNumber = $xmlBody->order->debitSale->transactionDetail->payType->debitCard->number;
-                
+
                 $xmlBody->verification->merchantId = LknIntegrationRedeForWoocommerceHelper::censorString($xmlBody->verification->merchantId, 3);
                 $xmlBody->verification->merchantKey = LknIntegrationRedeForWoocommerceHelper::censorString($xmlBody->verification->merchantKey, 12);
                 $xmlBody->order->debitSale->transactionDetail->payType->debitCard->number = LknIntegrationRedeForWoocommerceHelper::censorString($cardNumber, 8);
-                
+
                 $orderLogsArray = array(
                     'url' => $apiUrl,
                     'body' => $xmlBody,
                     'response' => $xml
                 );
-                
+
                 $orderLogs = json_encode($orderLogsArray);
                 $order->update_meta_data('lknWcRedeOrderLogs', $orderLogs);
             }
@@ -473,16 +481,16 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
                 $order->update_meta_data('_wc_maxipago_transaction_expiration', $creditExpiry);
                 $order->update_status('processing');
                 apply_filters("integrationRedeChangeOrderStatus", $order, $this);
-            }elseif(isset($xml_decode['responseCode']) && "1" == $xml_decode['responseCode']){
+            } elseif (isset($xml_decode['responseCode']) && "1" == $xml_decode['responseCode']) {
                 throw new Exception($xml_decode['processorMessage']);
             }
-            
+
 
             if ("INVALID REQUEST" == $xml_decode['responseMessage']) {
                 throw new Exception($xml_decode['errorMessage']);
             }
             //Caso não exista nenhuma das Message, o Merchant ID ou Merchant Key estão invalidos
-            if ( ! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
+            if (! isset($xml_decode['processorMessage']) && ! isset($xml_decode['processorMessage'])) {
                 throw new Exception(__("Merchant ID or Merchant Key is invalid!", 'woo-rede'));
             }
 
@@ -498,7 +506,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
 
         if (isset($xml_decode['authenticationURL'])) {
             $order->update_status('pending');
-    
+
             return array(
                 'result' => 'success',
                 'redirect' => $xml_decode['authenticationURL'],
@@ -511,7 +519,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         );
     }
 
-    public function validateCpfCnpj($cpfCnpj) {
+    public function validateCpfCnpj($cpfCnpj)
+    {
         // Remove caracteres especiais
         $cpfCnpj = preg_replace('/[^0-9]/', '', $cpfCnpj);
 
@@ -577,7 +586,8 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         return false;
     }
 
-    public function displayMeta($order): void {
+    public function displayMeta($order): void
+    {
         if ($order->get_payment_method() === 'maxipago_debit') {
             $metaKeys = array(
                 '_wc_maxipago_transaction_environment' => esc_attr__('Environment', 'woo-rede'),
@@ -596,17 +606,18 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         }
     }
 
-    public function checkoutScripts(): void {
+    public function checkoutScripts(): void
+    {
         $plugin_url = plugin_dir_url(LknIntegrationRedeForWoocommerceWcRede::FILE) . '../';
         if ($this->get_option('enabled_fix_load_script') === 'yes') {
             wp_enqueue_script('fixInfiniteLoading-js', $plugin_url . 'Public/js/fixInfiniteLoading.js', array(), '1.0.0', true);
         }
 
-        if ( ! is_checkout()) {
+        if (! is_checkout()) {
             return;
         }
 
-        if ( ! $this->is_available()) {
+        if (! $this->is_available()) {
             return;
         }
 
@@ -626,4 +637,3 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
         apply_filters('integrationRedeSetCustomCSSPro', get_option('woocommerce_maxipago_debit_settings')['custom_css_short_code'] ?? false);
     }
 }
-?>


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: rede, payment, credit, debit, pix

Testado até: 6.7.1

Versão estável: 3.7.3

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.

## Descrição

Integre Rede ou Maxipago à sua loja WooCommerce e habilite seus clientes a pagarem com cartão de crédito ou débito.

A [Rede](https://www.userede.com.br/) faz parte do grupo Itaú Unibanco e é uma adquirente responsável pela captura, transmissão e liquidação financeira de transações com cartões de crédito das bandeiras Visa, Mastercard, Elo, American Express, Hipercard, Hyper, Diners Club International, Cabal, Discover, China Union Pay, Aura, Sorocred, Coopercred, Sicredi, Mais!, Calcard, Banescard, Avista! no território brasileiro.

O [Maxipago](https://www.userede.com.br/n/gateway-de-pagamento-rede), que também faz parte do grupo Rede, fornece uma plataforma de gateway de pagamento segura e eficiente para empresas aceitarem os principais cartões de crédito e débito no Brasil. Com segurança avançada e prevenção de fraudes, ele garante a segurança das transações e a confiança do cliente, oferecendo integração simples e suporte para empresas de todos os tamanhos.
## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Resumo(3.7.3):

> Correção durante o mudanças de status para reembolso ou cancelamento do pedido: 

![image](https://github.com/user-attachments/assets/727f3e14-3a09-4a95-9b3d-936ef2aaf302)

![image](https://github.com/user-attachments/assets/1c31eb8c-5dfd-4df4-9715-6e25149a10f2)


