### PR TITLE
3.9.3 - integration-rede-for-woocommerce (Mudança nos logs de pagamento da Rede)

### DIFF
--- a/Includes/LknIntegrationRedeForWoocommerceTransactionException.php
+++ b/Includes/LknIntegrationRedeForWoocommerceTransactionException.php
@@ -8,9 +8,9 @@ class LknIntegrationRedeForWoocommerceTransactionException extends Exception
 {
     private $additionalData;
 
-    public function __construct($message, $code = 0, $additionalData = [], Exception $previous = null)
+    public function __construct($message, $code = 0, $additionalData = [])
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, $code);
         $this->additionalData = $additionalData;
     }
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeAPI.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeAPI.php
@@ -75,13 +75,12 @@ final class LknIntegrationRedeForWoocommerceWcRedeAPI
 
             return $transaction;
         } catch (Exception $e) {
-            $transactionTId = $transaction->getTid() ?? null;
+            $transactionTId = isset($transaction) && method_exists($transaction, 'getTid') ? $transaction->getTid() : null;
 
             throw new LknIntegrationRedeForWoocommerceTransactionException(
-                $e->getMessage(),
-                $e->getCode(),
-                ['tid' => $transactionTId],
-                $e
+                esc_html($e->getMessage()),
+                intval($e->getCode()),
+                ['tid' => esc_html($transactionTId)]
             );
         }
     }
@@ -119,13 +118,12 @@ final class LknIntegrationRedeForWoocommerceWcRedeAPI
 
             return $transaction;
         } catch (Exception $e) {
-            $transactionTId = $transaction->getTid() ?? null;
+            $transactionTId = isset($transaction) && method_exists($transaction, 'getTid') ? $transaction->getTid() : null;
 
             throw new LknIntegrationRedeForWoocommerceTransactionException(
-                $e->getMessage(),
-                $e->getCode(),
-                ['tid' => $transactionTId],
-                $e
+                esc_html($e->getMessage()),
+                intval($e->getCode()),
+                ['tid' => esc_html($transactionTId)]
             );
         }
     }


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: rede, payment, credit, debit, pix

Testado até: 6.7.1

Versão estável: 3.9.3

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.

## Descrição

Integre Rede ou Maxipago à sua loja WooCommerce e habilite seus clientes a pagarem com cartão de crédito ou débito.

A [Rede](https://www.userede.com.br/) faz parte do grupo Itaú Unibanco e é uma adquirente responsável pela captura, transmissão e liquidação financeira de transações com cartões de crédito das bandeiras Visa, Mastercard, Elo, American Express, Hipercard, Hyper, Diners Club International, Cabal, Discover, China Union Pay, Aura, Sorocred, Coopercred, Sicredi, Mais!, Calcard, Banescard, Avista! no território brasileiro.

O [Maxipago](https://www.userede.com.br/n/gateway-de-pagamento-rede), que também faz parte do grupo Rede, fornece uma plataforma de gateway de pagamento segura e eficiente para empresas aceitarem os principais cartões de crédito e débito no Brasil. Com segurança avançada e prevenção de fraudes, ele garante a segurança das transações e a confiança do cliente, oferecendo integração simples e suporte para empresas de todos os tamanhos.
## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Resumo(3.9.3):

- Mudança nos logs de pagamento dos cartões da `Rede`:
>
![image](https://github.com/user-attachments/assets/df4f264c-eb61-45df-b74e-c6c2a4de320d)

## Resumo do Copilot:

Esta pull request introduz a versão 3.9.3 do plugin Integration Rede for WooCommerce, com foco em melhorias no tratamento de erros, aprimoramento de logs e pequenas atualizações na documentação e metadados. Abaixo está um resumo das mudanças mais importantes:

### Novos Recursos e Melhorias
* Adicionado um novo método `getTransactionBrandDetails` na classe `LknIntegrationRedeForWoocommerceHelper` para recuperar detalhes da bandeira da transação via API. Isso inclui suporte para ambientes de produção e sandbox.
* Introduzida uma nova classe de exceção `LknIntegrationRedeForWoocommerceTransactionException` para encapsular dados adicionais (por exemplo, ID da transação) ao lidar com erros de transação.

### Melhorias no Tratamento de Erros
* Envolvidas as requisições de transações de crédito e débito em blocos `try-catch` na classe `LknIntegrationRedeForWoocommerceWcRedeAPI`. Em caso de falha, a nova classe de exceção é usada para fornecer dados detalhados sobre o erro. [[1]](diffhunk://#diff-44a9db5fa0c5d1c79a01721774519df5f767ad8cca80b47bf9d45cfd6aed746eR53) [[2]](diffhunk://#diff-44a9db5fa0c5d1c79a01721774519df5f767ad8cca80b47bf9d45cfd6aed746eR101)
* Atualizados os métodos `process_payment` nas classes de crédito e débito para registrar detalhes adicionais da transação (por exemplo, bandeira e código de retorno) quando ocorrem exceções. [[1]](diffhunk://#diff-4a0538332b8102257beb305e1ed78b0f8e2364b10161d92da7d955703273e106R498-R507) [[2]](diffhunk://#diff-f1569878978605de3f344c6f88b008809c6bcd513e1de7082d55f78866c42bfdR383-R395)

### Melhorias nos Logs
* Aprimorados os métodos `regOrderLogs` nas classes de crédito e débito para incluir a bandeira da transação e o código de retorno nos logs. [[1]](diffhunk://#diff-4a0538332b8102257beb305e1ed78b0f8e2364b10161d92da7d955703273e106L409-R418) [[2]](diffhunk://#diff-f1569878978605de3f344c6f88b008809c6bcd513e1de7082d55f78866c42bfdL305-R313)
* Atualizado o método `showOrderLogs` para garantir que a opção `show_order_logs` seja explicitamente verificada antes de exibir os logs.

### Atualizações de Versão e Documentação
* Atualizadas as referências de versão para `3.9.3` em vários arquivos, incluindo `.github/workflows`, `README.txt` e metadados do plugin. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L12-R12) [[2]](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398L7-R7) [[3]](diffhunk://#diff-3260fbe60c40b87f86d147e3eebed39abc056b2d5a1481c180454d67145588bdL18-R18)
* Adicionada uma entrada no changelog para a versão 3.9.3, destacando as mudanças nos logs de feedback para o método de pagamento Rede. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R3) [[2]](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398R75-R77)

Essas mudanças coletivamente aumentam a robustez do plugin, melhoram as capacidades de depuração e garantem versionamento e documentação precisos.