### PR TITLE
4.0.0 - integration-rede-for-woocommerce (Adição do conversão + correções de erros, bugs e warnings)

### DIFF
--- a/Includes/templates/creditCard/maxipagoPaymentCreditForm.php
+++ b/Includes/templates/creditCard/maxipagoPaymentCreditForm.php
@@ -329,7 +329,7 @@ $option = get_option('woocommerce_maxipago_credit_settings');
                         $default_installment = isset($installments_number) ? (int)$installments_number : 1;
                         foreach ($installments as $installment) {
                             $selected = ($installment['num'] == $default_installment) ? 'selected' : '';
-                            printf('<option value="%d" %s>%s</option>', esc_attr($installment['num']), $selected, esc_html($installment['label']));
+                            printf('<option value="%d" %s>%s</option>', esc_attr($installment['num']), esc_attr($selected), esc_html($installment['label']));
                         }
                     ?>
                 </select>

--- a/Includes/templates/creditCard/redePaymentCreditForm.php
+++ b/Includes/templates/creditCard/redePaymentCreditForm.php
@@ -258,7 +258,7 @@ $option = get_option('woocommerce_rede_credit_settings');
                         $default_installment = isset($installments_number) ? (int)$installments_number : 1;
                         foreach ($installments as $installment) {
                             $selected = ($installment['num'] == $default_installment) ? 'selected' : '';
-                            printf('<option value="%d" %s>%s</option>', esc_attr($installment['num']), $selected, esc_html($installment['label']));
+                            printf('<option value="%d" %s>%s</option>', esc_attr($installment['num']), esc_attr($selected), esc_html($installment['label']));
                         }
                     ?>
                 </select>


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: rede, payment, credit, debit, pix

Testado até: 6.7.1

Versão estável: 4.0.0

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.

## Descrição

Integre Rede ou Maxipago à sua loja WooCommerce e habilite seus clientes a pagarem com cartão de crédito ou débito.

A [Rede](https://www.userede.com.br/) faz parte do grupo Itaú Unibanco e é uma adquirente responsável pela captura, transmissão e liquidação financeira de transações com cartões de crédito das bandeiras Visa, Mastercard, Elo, American Express, Hipercard, Hyper, Diners Club International, Cabal, Discover, China Union Pay, Aura, Sorocred, Coopercred, Sicredi, Mais!, Calcard, Banescard, Avista! no território brasileiro.

O [Maxipago](https://www.userede.com.br/n/gateway-de-pagamento-rede), que também faz parte do grupo Rede, fornece uma plataforma de gateway de pagamento segura e eficiente para empresas aceitarem os principais cartões de crédito e débito no Brasil. Com segurança avançada e prevenção de fraudes, ele garante a segurança das transações e a confiança do cliente, oferecendo integração simples e suporte para empresas de todos os tamanhos.
## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Resumo(4.0.0):

* Adição do campo de conversão de moeda.
* Correções de bugs e warnings.