### PR TITLE
5.1.0 - integration-rede-for-woocommerce(Novo sistema de requisição 3DS via Rede débito/crédito + OAuth 2.0)

### DIFF
--- a/Admin/js/lkn-integration-rede-for-woocommerce-settings-layout.js
+++ b/Admin/js/lkn-integration-rede-for-woocommerce-settings-layout.js
@@ -203,7 +203,7 @@
                             if (typeof lknPhpProFieldsVariables !== 'undefined' && lknPhpProFieldsVariables.becomePRO) {
                                 proLink.textContent = lknPhpProFieldsVariables.becomePRO;
                             } else {
-                                proLink.textContent = 'Become PRO'; // fallback text
+                                proLink.textContent = 'PRO'; // fallback text
                             }
                             
                             titleHeader.appendChild(proLink);

--- a/Includes/LknIntegrationRedeForWoocommerce.php
+++ b/Includes/LknIntegrationRedeForWoocommerce.php
@@ -1256,7 +1256,7 @@ final class LknIntegrationRedeForWoocommerce
         $settings = get_option('woocommerce_' . $chosen_payment_method . '_settings', array());
         $min_parcels_value = isset($settings['min_parcels_value']) ? floatval($settings['min_parcels_value']) : 5;
         
-        if (empty($min_parcels_value) || $min_parcels_value < 5) {
+        if (empty($min_parcels_value) || !is_numeric($min_parcels_value) || $min_parcels_value < 5) {
             $min_parcels_value = 5;
         }
 


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 6.8

Versão estável: 5.1.0

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Novidades (5.1.0):

* Novo sistema de requisição via 3DS no débito da Rede.
* Novo sistema OAuth 2.0

## CHANGELOG:

* Novo sistema de requisição via 3DS no débito da Rede.
* Novo sistema de requisições da Rede V2 para maior estabilidade
* Implementação de cron automático para verificação de PIX com timeout de 24h
* Melhoria significativa na performance dos scripts de checkout
* Otimização do sistema de parcelas com reset automático
* Correções de segurança e validações aprimoradas
* Compatibilidade aprimorada com shortcodes do WooCommerce
* Sistema de logs mais detalhado para debugging