### PR TITLE
5.1.7 - integration-rede-for-woocommerce(Adição do campo de referência às notas do pedido)

### DIFF
--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -707,7 +707,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
         // Se a licença PRO não for válida, resetar campos PRO para valores padrão
         // Se a licença PRO não for válida, forçar valores padrão após o salvamento
         if (!LknIntegrationRedeForWoocommerceHelper::isProLicenseValid()) {
-            $this->enforceProFieldDefaults();
+            $this->enforceProFieldDefaults($this->id);
 
             $option_key = "woocommerce_{$this->id}_settings";
             $current_settings = get_option($option_key, array());


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 6.9

Versão estável: 5.1.7

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Novidades (5.1.7):

* Adição do campo de referência às notas do pedido.

## CHANGELOG:

* Novo sistema de requisição via 3DS no débito da Rede.
* Novo sistema de requisições da Rede V2 para maior estabilidade
* Implementação de cron automático para verificação de PIX com timeout de 24h
* Melhoria significativa na performance dos scripts de checkout
* Otimização do sistema de parcelas com reset automático
* Correções de segurança e validações aprimoradas
* Compatibilidade aprimorada com shortcodes do WooCommerce
* Sistema de logs mais detalhado para debugging
* Mudança na versão do IONCUBE.
* Ajustes no CRON + Webbook.
* AJuste na obtenção da bandeira do cartão nas notas do pedido
* Ajuste de vulnerabilidade na rota de deleção de logs.
* Adição do campo de referência às notas do pedido.

## SCREENSHOTS:

<img width="320" height="360" alt="image" src="https://github.com/user-attachments/assets/d0c5a76f-a84e-4110-b765-66d65f410017" />
