### PR TITLE
5.3.0 - integration-rede-for-woocommerce(Novo método de pagamento: Google Pay)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -10,7 +10,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.2.1"
+  DEPLOY_TAG: "5.3.0"
 
 jobs:
   release-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.2.1"
+  DEPLOY_TAG: "5.3.0"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.2.1"
+  DEPLOY_TAG: "5.3.0"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 5.2.1 - 24/02/2026
+# 5.3.0 - 24/02/2026
 * Adição do novo método de pagamento Google Pay.
 
 # 5.2.0 - 12/02/2026

--- a/Includes/LknIntegrationRedeForWoocommerceHelper.php
+++ b/Includes/LknIntegrationRedeForWoocommerceHelper.php
@@ -1307,6 +1307,7 @@ class LknIntegrationRedeForWoocommerceHelper
         unset($order_statuses["wc-checkout-draft"]);
         unset($order_statuses["wc-refunded"]);
         unset($order_statuses["wc-cancelled"]);
+
         return $order_statuses;
     }
 }

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -249,7 +249,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
      */
     private function generateMetaTableWithBrandIcon($order, $metaKeys, $title): void
     {
-?>
+        ?>
         <h3 style="margin-bottom: 14px;"><?php echo esc_html($title); ?></h3>
         <table>
             <tbody>
@@ -274,7 +274,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
                 ?>
             </tbody>
         </table>
-<?php
+        <?php
     }
 
     public function initFormFields(): void

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: rede, PIX, cartao credito, itau, pagamento  
 Requires at least: 5.0  
 Tested up to: 6.9  
-Stable tag: 5.2.1
+Stable tag: 5.3.0
 Requires PHP: 7.2  
 License: GPLv3 or later  
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -124,7 +124,7 @@ A: Yes — tested up to WordPress 6.8.
 ---
 
 ## Changelog
-### 5.2.1 - 2026/02/24
+### 5.3.0 - 2026/02/24
 - Addition of the new Google Pay payment method.
 
 ### 5.2.0 - 2026/02/12

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede Itaú for WooCommerce — Payment PIX, Credit Card and Debit
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           5.2.1
+ * Version:           5.3.0
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/wordpress
  * License:           GPL-3.0+

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.2.1');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.3.0');
 }
 
 if (! defined('LKN_WC_REDE_WPP_NUMBER')) {


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 6.9

Versão estável: 5.3.0

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Novidades (5.3.0):

* Adição do novo método de pagamento Google Pay.

## CHANGELOG:

* Adição do novo método de pagamento Google Pay.

## SCREENSHOTS:

<img width="703" height="185" alt="image" src="https://github.com/user-attachments/assets/c0348beb-29d0-4124-8271-6aa6b57ba9fc" />

<img width="617" height="610" alt="image" src="https://github.com/user-attachments/assets/bcd86ca8-4155-419f-8872-976107fc70af" />