### PR TITLE
5.4.2 - integration-rede-for-woocommerce(Migração do hook de cancelamento do pedido para versão PRO)

### DIFF
--- a/Includes/LknIntegrationRedeForWoocommerce.php
+++ b/Includes/LknIntegrationRedeForWoocommerce.php
@@ -1198,6 +1198,7 @@ final class LknIntegrationRedeForWoocommerce
                     
                     // translators: %s is the order total amount
                     $order->add_order_note(sprintf(__('Manual PIX Verification: Payment of %s confirmed by Rede.', 'woo-rede'), $order_total));
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($paymentCompleteStatus);
                 } else {
                     // translators: %s is the order total amount

--- a/Includes/LknIntegrationRedeForWoocommerceGooglePay.php
+++ b/Includes/LknIntegrationRedeForWoocommerceGooglePay.php
@@ -554,6 +554,7 @@ final class LknIntegrationRedeForWoocommerceGooglePay extends LknIntegrationRede
                 // Update order status based on configuration
                 $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
                 if (!empty($payment_complete_status) && $payment_complete_status !== $order->get_status()) {
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($payment_complete_status);
                 }
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -289,6 +289,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
                 if ("" == $paymentCompleteStatus) {
                     $paymentCompleteStatus = 'processing';
                 }
+                $order->set_date_paid(current_time('timestamp', true));
                 $order->update_status($paymentCompleteStatus);
                 break;
             case '9':
@@ -337,6 +338,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
                             $paymentCompleteStatus = 'processing';
                         }
                         
+                        $order->set_date_paid(current_time('timestamp', true));
                         $order->update_status($paymentCompleteStatus, __('PIX payment confirmed via webhook - FREE version', 'woo-rede'));
                         
                         // Limpar cron de verificação se existir
@@ -513,6 +515,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
                         $paymentCompleteStatus = 'processing';
                     }
                     
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($paymentCompleteStatus, __('PIX payment confirmed via webhook - PRO version', 'woo-rede'));
 
                     // Log 8: Finalização PRO
@@ -544,6 +547,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
                         ));
                     }
                     
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status('processing', __('PIX payment confirmed via webhook - FREE version', 'woo-rede'));
                     
                     // Log 10: Finalização FREE
@@ -635,6 +639,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
             if ("" == $paymentCompleteStatus) {
                 $paymentCompleteStatus = 'processing';
             }
+            $order->set_date_paid(current_time('timestamp', true));
             $order->update_status($paymentCompleteStatus);
 
             $order->save();
@@ -835,6 +840,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
                 if ($capture) {
                     // Status configurável pelo usuário para pagamentos aprovados com captura
                     $payment_complete_status = $gateway_settings['payment_complete_status'] ?? 'processing';
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($payment_complete_status);
                 } else {
                     // Para pagamentos credit sem captura, aguardando captura manual

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
@@ -743,6 +743,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
 
                 if ('sale' == $capture) {
                     $order->update_meta_data('_wc_rede_captured', true);
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status('processing');
                     apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
                 }

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
@@ -659,6 +659,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
                 $order->update_meta_data('_wc_maxipago_transaction_environment', $environment);
                 $order->update_meta_data('_wc_maxipago_transaction_holder', $cardData['card_holder']);
                 $order->update_meta_data('_wc_maxipago_transaction_expiration', $debitExpiry);
+                $order->set_date_paid(current_time('timestamp', true));
                 $order->update_status('processing');
                 apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
             } elseif (isset($xml_decode['responseCode']) && "1" == $xml_decode['responseCode']) {

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeAbstract.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeAbstract.php
@@ -255,6 +255,7 @@ abstract class LknIntegrationRedeForWoocommerceWcRedeAbstract extends WC_Payment
                 if ($transaction->getCapture()) {
                     // Status configurável pelo usuário para pagamentos aprovados
                     $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($payment_complete_status);
                     apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
                 } else {

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -725,6 +725,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
                 if ($capture) {
                     // Status configurável pelo usuário para pagamentos aprovados com captura
                     $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($payment_complete_status);
                     apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
                 } else {

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -164,6 +164,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
                 if ($capture) {
                     // Status configurável pelo usuário para pagamentos aprovados com captura
                     $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
+                    $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($payment_complete_status);
                     apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
                 } else {


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 6.9

Versão estável: 5.4.2

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Migração do hook de cancelamento do pedido para versão PRO.