### PR TITLE
5.4.2 - integration-rede-for-woocommerce(Migração do hook de cancelamento do pedido para versão PRO)

### DIFF
--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -37,8 +37,9 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
         if ($this->get_option('enabled_soft_descriptor') === 'yes') {
             $this->soft_descriptor = preg_replace('/\W/', '', $this->get_option('soft_descriptor'));
         } elseif ($this->get_option('enabled_soft_descriptor') === 'no') {
-            add_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorCredit', false);
-            update_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorCredit', false);
+            if (get_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorCredit')) {
+                update_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorCredit', false);
+            }
         }
 
         // Auto capture com validação PRO - se não tiver licença PRO válida, força auto_capture como true

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -50,8 +50,9 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
         if ($this->get_option('enabled_soft_descriptor') === 'yes') {
             $this->soft_descriptor = preg_replace('/\W/', '', $this->get_option('soft_descriptor'));
         } elseif ($this->get_option('enabled_soft_descriptor') === 'no') {
-            add_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorDebit', false);
-            update_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorDebit', false);
+            if (get_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorDebit')) {
+                update_option('lknIntegrationRedeForWoocommerceSoftDescriptorErrorDebit', false);
+            }
         }
 
         // Auto capture configurável igual ao rede_credit


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 6.9

Versão estável: 5.4.2

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Migração do hook de cancelamento do pedido para versão PRO.