### PR TITLE
5.4.3 - integration-rede-for-woocommerce(AJuste nos logs de erro do 3DS)

### DIFF
--- a/Includes/LknIntegrationRedeForWoocommerceHelper.php
+++ b/Includes/LknIntegrationRedeForWoocommerceHelper.php
@@ -84,6 +84,79 @@ class LknIntegrationRedeForWoocommerceHelper
     }
 
     /**
+     * Detecta a bandeira do cartão a partir do BIN (primeiros 6 dígitos).
+     * Usado como fallback quando o TID não está disponível (ex: returnCode 64).
+     * Retorna apenas o nome da bandeira; os demais campos do objeto brand não
+     * são recuperáveis sem TID pois dependem de uma autorização concluída.
+     */
+    final public static function getBrandFromBin($bin)
+    {
+        if (empty($bin)) {
+            return '';
+        }
+
+        $bin = preg_replace('/\D/', '', $bin);
+        $bin6 = substr($bin, 0, 6);
+        $bin4 = substr($bin, 0, 4);
+        $bin2 = substr($bin, 0, 2);
+        $bin1 = substr($bin, 0, 1);
+
+        // Hipercard
+        $hipercard_bins = array('606282', '637095', '637568', '637599', '637609', '637612');
+        if (in_array($bin6, $hipercard_bins, true)) {
+            return 'Hipercard';
+        }
+
+        // Elo — principais faixas usadas no Brasil
+        $elo_bin6_list = array(
+            '401178', '401179', '438935', '451416', '457393', '504175',
+            '506699', '506778', '509000', '509999', '627780', '636297',
+            '636368', '650031', '650033', '650035', '650051', '650405',
+            '650439', '650485', '650486', '650487', '650488', '650489',
+            '650491', '650495', '650501', '650503', '650506', '650533',
+            '650536', '650540', '650541', '650598', '650720', '650727',
+            '650901', '650978', '651652', '651679', '655000', '655019',
+            '655021', '655058',
+        );
+        $elo_bin4_list = array('4576', '4011', '5067');
+        if (in_array($bin6, $elo_bin6_list, true) || in_array($bin4, $elo_bin4_list, true)) {
+            return 'Elo';
+        }
+
+        // American Express
+        if (in_array($bin2, array('34', '37'), true)) {
+            return 'Amex';
+        }
+
+        // Diners Club
+        $diners_prefixes = array('300', '301', '302', '303', '304', '305');
+        if (in_array(substr($bin, 0, 3), $diners_prefixes, true) || in_array($bin2, array('36', '38'), true)) {
+            return 'Diners';
+        }
+
+        // Discover
+        if ($bin4 === '6011' || $bin2 === '65') {
+            return 'Discover';
+        }
+
+        // Mastercard — BIN 51-55 e faixa 2221-2720
+        if (in_array($bin2, array('51', '52', '53', '54', '55'), true)) {
+            return 'Mastercard';
+        }
+        $bin_int4 = intval($bin4);
+        if ($bin_int4 >= 2221 && $bin_int4 <= 2720) {
+            return 'Mastercard';
+        }
+
+        // Visa
+        if ($bin1 === '4') {
+            return 'Visa';
+        }
+
+        return '';
+    }
+
+    /**
      * Busca dados completos da transação pela API da Rede usando TID
      * e preenche metadados faltantes no pedido
      */

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -720,6 +720,8 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
     {
         $parameters = $request->get_params();
 
+        error_log(json_encode($parameters));
+
         // Extrai o order_id da reference (formato: order_id-timestamp)
         $reference = sanitize_text_field($parameters['reference'] ?? '');
         
@@ -772,6 +774,39 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
         $gateway_config = $this->get_dynamic_gateway_config($order);
         $gateway = $gateway_config['gateway_instance'];
         $gateway_settings = $gateway_config['settings'];
+
+        // Fallback nível 1: TID disponível → buscar objeto brand completo via API
+        if (empty($brand) && $gateway) {
+            $tid_for_brand = !empty($parameters['tid']) && trim($parameters['tid']) !== '' ? trim($parameters['tid']) : $order->get_meta('_wc_rede_transaction_id');
+            if (!empty($tid_for_brand)) {
+                $brand_details = LknIntegrationRedeForWoocommerceHelper::getTransactionBrandDetails($tid_for_brand, $gateway);
+                if (!empty($brand_details['brand']['name'])) {
+                    $brand = $brand_details['brand']['name'];
+                    $order->update_meta_data('_wc_rede_transaction_card_brand', ucfirst($brand));
+                    $order->update_meta_data('_wc_rede_brand_return_code', $brand_details['brand']['returnCode'] ?? '');
+                    $order->update_meta_data('_wc_rede_brand_tid', $brand_details['brand']['brandTid'] ?? '');
+                    $order->update_meta_data('_wc_rede_brand_authorization_code', $brand_details['brand']['authorizationCode'] ?? '');
+                    $order->update_meta_data('_wc_rede_brand_return_message', $brand_details['brand']['returnMessage'] ?? '');
+                }
+            }
+        }
+
+        // Fallback nível 2: sem TID (ex: returnCode 64) → detectar nome da bandeira pelo BIN
+        // Neste caso os campos brandTid/authorizationCode não existem pois não houve autorização
+        if (empty($brand)) {
+            $bin = $order->get_meta('_wc_rede_transaction_bin');
+            if (!empty($bin)) {
+                $brand_from_bin = LknIntegrationRedeForWoocommerceHelper::getBrandFromBin($bin);
+                if (!empty($brand_from_bin)) {
+                    $brand = $brand_from_bin;
+                    $order->update_meta_data('_wc_rede_transaction_card_brand', $brand);
+                    $order->update_meta_data('_wc_rede_brand_return_code', !empty($parameters['brand_returnCode']) && trim($parameters['brand_returnCode']) !== '' ? $parameters['brand_returnCode'] : '');
+                    $order->update_meta_data('_wc_rede_brand_tid', '');
+                    $order->update_meta_data('_wc_rede_brand_authorization_code', '');
+                    $order->update_meta_data('_wc_rede_brand_return_message', !empty($parameters['brand_returnMessage']) && trim($parameters['brand_returnMessage']) !== '' ? $parameters['brand_returnMessage'] : '');
+                }
+            }
+        }
 
         LknIntegrationRedeForWoocommerceHelper::saveTransactionMetadata(
             $order, 
@@ -886,12 +921,27 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
                     $tId = $transaction['tid'] ?? null;
                     $returnCode = $transaction['returnCode'] ?? null;
                 }
-                
+
                 if ($tId) {
                     $brand = LknIntegrationRedeForWoocommerceHelper::getTransactionBrandDetails($tId, $gateway);
                 }
+
+                // Fallback: se brand ainda é null (sem TID ou falha na API), usar metadados salvos no pedido
+                if ($brand === null) {
+                    $brand_name = $order->get_meta('_wc_rede_transaction_card_brand');
+                    $brand = array(
+                        'brand' => array(
+                            'name'              => $brand_name ?: '',
+                            'returnCode'        => $order->get_meta('_wc_rede_brand_return_code') ?: '',
+                            'brandTid'          => $order->get_meta('_wc_rede_brand_tid') ?: '',
+                            'authorizationCode' => $order->get_meta('_wc_rede_brand_authorization_code') ?: '',
+                            'returnMessage'     => $order->get_meta('_wc_rede_brand_return_message') ?: '',
+                        ),
+                        'returnCode' => $order->get_meta('_wc_rede_brand_return_code') ?: '',
+                    );
+                }
             }
-            
+
             $default_currency = get_option('woocommerce_currency', 'BRL');
             $order_currency = method_exists($order, 'get_currency') ? $order->get_currency() : $default_currency;
             $currency_json_path = INTEGRATION_REDE_FOR_WOOCOMMERCE_DIR . 'Includes/files/linkCurrencies.json';
@@ -921,7 +971,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
                 'cardData' => $cardData,
                 'cardType' => $final_card_type,
                 'installments' => ($final_card_type === 'credit' && $final_installments >= 1) ? $final_installments : null,
-                'brand' => isset($tId) && isset($brand) ? $brand['brand'] : null,
+                'brand' => isset($brand['brand']) ? $brand['brand'] : null,
                 'returnCode' => isset($returnCode) ? $returnCode : null,
             );
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -720,8 +720,6 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
     {
         $parameters = $request->get_params();
 
-        error_log(json_encode($parameters));
-
         // Extrai o order_id da reference (formato: order_id-timestamp)
         $reference = sanitize_text_field($parameters['reference'] ?? '');
         


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 6.9

Versão estável: 5.4.3

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste na lógica dos logs com erro no 3DS.