### PR TITLE
5.4.4 - integration-rede-for-woocommerce(AJuste nos notas e status dos pedidos)

### DIFF
--- a/.github/workflows/copilot-instructions.md
+++ b/.github/workflows/copilot-instructions.md
@@ -1,0 +1,117 @@
+# Integration Rede Itaú for WooCommerce — Development Guidelines
+
+## Plugin Overview
+
+- **Plugin**: `integration-rede-for-woocommerce` (slug: `woo-rede`)
+- **Stack**: PHP 8.2+, WordPress 6.8+, WooCommerce, React (Blocks)
+- **Text Domain**: `woo-rede`
+- **Prefix**: `LknIntegrationRedeForWoocommerce` (classes), `lkn_` (functions/hooks)
+- **Gateways**: `rede_credit`, `rede_debit`, `integration_rede_pix`, `rede_pix`, `rede_google_pay`, `maxipago_credit`, `maxipago_debit`
+
+## Architecture & SOLID Principles
+
+**Single Responsibility Principle (SRP)**
+- `LknIntegrationRedeForWoocommerce` — orchestrates hooks and plugin lifecycle only
+- `LknIntegrationRedeForWoocommerceWcRedeCredit` / `*Debit` / `*PixRede` — each gateway owns its own payment flow
+- `LknIntegrationRedeForWoocommerceHelper` — shared utilities (token, metadata, BIN, logging)
+- `LknIntegrationRedeForWoocommerceWcEndpoint` — REST endpoint and webhook handling only
+- `LknIntegrationRedeForWoocommerceAdmin` / `*Public` — admin vs. frontend concerns
+- Do not add unrelated logic to existing classes; create a new class if needed
+
+**Open/Closed Principle (OCP)**
+- Extend gateway behavior through WooCommerce hooks and custom filters, never by patching core flow
+- Use `apply_filters('integration_rede_for_woocommerce_*', ...)` and `do_action('integration_rede_for_woocommerce_*', ...)` for extensibility
+- The PRO plugin extends FREE plugin via filters — keep integration points clean and documented
+
+**Liskov Substitution Principle (LSP)**
+- All gateways extend `WC_Payment_Gateway`; `*Credit` and `*Debit` both extend `LknIntegrationRedeForWoocommerceWcRedeAbstract`
+- Subclasses must not break the contract of `process_payment()`, `process_refund()`, or `process_admin_options()`
+
+**Interface Segregation Principle (ISP)**
+- Block integrations live in dedicated `*Blocks.php` classes (e.g., `LknIntegrationRedeForWoocommerceWcRedeCreditBlocks`)
+- Do not add Blocks logic to the main gateway class
+
+**Dependency Inversion Principle (DIP)**
+- Gateway classes receive configuration via `get_option()` / `$this->get_option()`, not hardcoded values
+- OAuth token retrieval is delegated to `LknIntegrationRedeForWoocommerceHelper` — gateways must not call the Rede API directly for auth
+
+## Code Standards
+
+**WordPress / WooCommerce**
+- PHP 8.2+, WordPress Coding Standards
+- Always use `wp_verify_nonce()` on form submissions and AJAX handlers
+- Sanitize all inputs: `sanitize_text_field()`, `absint()`, `wp_unslash()`, etc.
+- Escape all outputs: `esc_html()`, `esc_attr()`, `esc_url()`, `wp_kses_post()`
+- Internationalize every user-facing string with text domain `woo-rede`: `__('text', 'woo-rede')`
+
+**Naming Conventions**
+- Classes: `LknIntegrationRedeForWoocommerce*`
+- Functions / hooks: `lkn_integration_rede_*` or `lkn_rede_*`
+- Meta keys: `_wc_rede_*` (private) or `lkn_rede_*` (public)
+- Session keys: `lkn_*`
+- Options: `woocommerce_{gateway_id}_settings`, `lkn_*`
+
+**Order Notes**
+- Every `$order->add_order_note()` call must prefix the message with `'[' . $this->id . '] '` (gateway classes) or `'[' . $gateway_id . '] '` (non-gateway contexts)
+- This marker is consumed by `add_gateway_name_to_notes_global()` to prepend the gateway title; notes without the marker are left untouched (third-party notes)
+
+**Order Status Updates**
+- `process_order_status_v2()` and `process_3ds_order_status()` must update the order status unconditionally based on the return code — do not guard with `has_status('pending')`
+- PIX webhook handlers may guard with `has_status('pending')` because multiple webhook calls can occur
+
+## Project Structure
+
+```
+Admin/                          # Admin-only assets and partials
+Includes/
+  LknIntegrationRedeForWoocommerce.php          # Core: hook orchestration
+  LknIntegrationRedeForWoocommerceHelper.php    # Shared utilities
+  LknIntegrationRedeForWoocommerceWcRedeAbstract.php  # Base for credit/debit
+  LknIntegrationRedeForWoocommerceWcRedeCredit.php
+  LknIntegrationRedeForWoocommerceWcRedeDebit.php
+  LknIntegrationRedeForWoocommerceWcPixRede.php
+  LknIntegrationRedeForWoocommerceGooglePay.php
+  LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+  LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+  LknIntegrationRedeForWoocommerceWcEndpoint.php  # REST / webhooks
+  LknIntegrationRedeForWoocommerce*Blocks.php     # Block checkout integrations
+Public/                         # Frontend-only assets
+languages/                      # .pot / .po files (text domain: woo-rede)
+uninstall.php                   # Cleanup on uninstall
+```
+
+## Build Commands
+
+```bash
+# Install dependencies
+npm install && composer install
+
+# Build assets
+npm run build
+```
+
+## WordPress Plugin Specifics
+
+**Hooks Priority**
+- Default priority (10) unless a specific order with WooCommerce hooks is required
+- Document non-default priorities inline
+
+**Database Operations**
+- Use `$wpdb->prepare()` for all custom queries
+- Prefer WooCommerce order meta API (`get_meta` / `update_meta_data`) over direct `postmeta` queries
+- Clean up all plugin data in `uninstall.php`
+
+**Asset Management**
+- Enqueue with `wp_enqueue_script()` / `wp_enqueue_style()` using `INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION` as version
+
+## Error Handling
+
+- Throw `LknIntegrationRedeForWoocommerceTransactionException` for payment transaction errors
+- Log debug information only when `$this->debug === 'yes'`
+- Never expose API credentials or raw stack traces to the frontend
+
+## Performance
+
+- Cache OAuth tokens using WordPress transients via `LknIntegrationRedeForWoocommerceHelper`
+- Avoid redundant API calls; reuse token data within a single request lifecycle
+- Do not load admin-only classes on the frontend

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -10,7 +10,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.3"
+  DEPLOY_TAG: "5.4.4"
 
 jobs:
   release-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.3"
+  DEPLOY_TAG: "5.4.4"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.3"
+  DEPLOY_TAG: "5.4.4"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.4.4 - 03/06/2026
+* Ajuste nas notas customizadas.
+* Ajuste na mudança do status do pedido.
+
 # 5.4.3 - 28/05/2026
 * Ajuste na lógica dos logs com erro no 3DS.
 

--- a/Includes/LknIntegrationRedeForWoocommerce.php
+++ b/Includes/LknIntegrationRedeForWoocommerce.php
@@ -1133,7 +1133,7 @@ final class LknIntegrationRedeForWoocommerce
         
         // Validar se é pedido PIX
         if (!self::is_pix_gateway($payment_method)) {
-            $order->add_order_note(__('Verificação PIX: Esta ação é aplicável apenas a pedidos com método de pagamento PIX.', 'woo-rede'));
+            $order->add_order_note('[' . $payment_method . '] ' . __('Verificação PIX: Esta ação é aplicável apenas a pedidos com método de pagamento PIX.', 'woo-rede'));
             return;
         }
         
@@ -1146,7 +1146,7 @@ final class LknIntegrationRedeForWoocommerce
         }
         
         if (empty($tId)) {
-            $order->add_order_note(__('Verificação PIX: Identificador da transação não localizado nos metadados do pedido.', 'woo-rede'));
+            $order->add_order_note('[' . $payment_method . '] ' . __('Verificação PIX: Identificador da transação não localizado nos metadados do pedido.', 'woo-rede'));
             return;
         }
         
@@ -1197,19 +1197,19 @@ final class LknIntegrationRedeForWoocommerce
                     }
                     
                     // translators: %s is the order total amount
-                    $order->add_order_note(sprintf(__('Manual PIX Verification: Payment of %s confirmed by Rede.', 'woo-rede'), $order_total));
+                    $order->add_order_note('[' . $gateway_id . '] ' . sprintf(__('Manual PIX Verification: Payment of %s confirmed by Rede.', 'woo-rede'), $order_total));
                     $order->set_date_paid(current_time('timestamp', true));
                     $order->update_status($paymentCompleteStatus);
                 } else {
                     // translators: %s is the order total amount
-                    $order->add_order_note(sprintf(__('Manual PIX Verification: Payment of %s confirmed by Rede.', 'woo-rede'), $order_total));
+                    $order->add_order_note('[' . $gateway_id . '] ' . sprintf(__('Manual PIX Verification: Payment of %s confirmed by Rede.', 'woo-rede'), $order_total));
                 }
             } else {
-                $order->add_order_note(__('Manual PIX Verification: Payment not confirmed by Rede. Transaction status: ', 'woo-rede') . $status);
+                $order->add_order_note('[' . $gateway_id . '] ' . __('Manual PIX Verification: Payment not confirmed by Rede. Transaction status: ', 'woo-rede') . $status);
             }
             
         } catch (\Exception $e) {
-            $order->add_order_note(__('Manual PIX Verification: Failed to query payment from Rede. Details: ', 'woo-rede') . $e->getMessage());
+            $order->add_order_note('[' . $gateway_id . '] ' . __('Manual PIX Verification: Failed to query payment from Rede. Details: ', 'woo-rede') . $e->getMessage());
         }
         
         $order->save();
@@ -1395,22 +1395,31 @@ final class LknIntegrationRedeForWoocommerce
 
             if ($order && is_a($order, 'WC_Order')) {
 
-                // Metodos do plugin integration rede e integration rede pro
-                $methods = ['maxipago_credit', 'maxipago_debit', 'integration_rede_pix', 'rede_credit', 'rede_debit', 'maxipago_pix', 'rede_pix'];
+                // Metodos do plugin integration rede (free) e integration rede pro
+                $methods = ['maxipago_credit', 'maxipago_debit', 'maxipago_pix', 'integration_rede_pix', 'rede_credit', 'rede_debit', 'rede_pix', 'rede_google_pay'];
                 $payment_method = $order->get_payment_method();
 
                 if (in_array($payment_method, $methods)) {
 
-                    $payment_gateways = WC()->payment_gateways->payment_gateways();
-                    $gateway_title = 'Rede'; // Fallback
+                    // Só processar notas que contenham o marcador [$payment_method] para ignorar plugins terceiros
+                    $pattern = '/\[' . preg_quote($payment_method, '/') . '\]\s*/';
+                    if (preg_match($pattern, $note_data['comment_content'])) {
 
-                    if (isset($payment_gateways[$payment_method])) {
-                        $gateway_title = $payment_gateways[$payment_method]->get_title();
-                    }
+                        // Remover o marcador do conteúdo
+                        $note_data['comment_content'] = preg_replace($pattern, '', $note_data['comment_content']);
 
-                    $prefix = $gateway_title . ' — ';
-                    if (strpos($note_data['comment_content'], $prefix) === false) {
-                        $note_data['comment_content'] = $prefix . $note_data['comment_content'];
+                        $payment_gateways = WC()->payment_gateways->payment_gateways();
+                        $gateway_title = 'Rede'; // Fallback
+
+                        if (isset($payment_gateways[$payment_method])) {
+                            $gateway_title = $payment_gateways[$payment_method]->get_title();
+                        }
+
+                        // Verificar se o prefixo já existe para evitar duplicação
+                        $prefix = $gateway_title . ' — ';
+                        if (strpos($note_data['comment_content'], $prefix) === false) {
+                            $note_data['comment_content'] = $prefix . $note_data['comment_content'];
+                        }
                     }
                 }
             }

--- a/Includes/LknIntegrationRedeForWoocommerceGooglePay.php
+++ b/Includes/LknIntegrationRedeForWoocommerceGooglePay.php
@@ -520,7 +520,7 @@ final class LknIntegrationRedeForWoocommerceGooglePay extends LknIntegrationRede
 
             if ($convert_to_brl_enabled) {
                 $order->add_order_note(
-                    sprintf(
+                    '[' . $this->id . '] ' . sprintf(
                         /* translators: %s: The original order currency code (e.g., USD, EUR) that was converted to BRL. */
                         __('Order currency %s converted to BRL.', 'woo-rede'),
                         $order_currency
@@ -559,7 +559,7 @@ final class LknIntegrationRedeForWoocommerceGooglePay extends LknIntegrationRede
                 }
 
                 // Add order note
-                $order->add_order_note(__('Payment completed via Google Pay', 'woo-rede'));
+                $order->add_order_note('[' . $this->id . '] ' . __('Payment completed via Google Pay', 'woo-rede'));
 
                 return array(
                     'result' => 'success',
@@ -568,7 +568,7 @@ final class LknIntegrationRedeForWoocommerceGooglePay extends LknIntegrationRede
             } else {
                 $error_message = isset($result['message']) ? $result['message'] : __('Payment failed', 'woo-rede');
                 /* translators: %s: The error message returned when a Google Pay payment fails. */
-                $order->add_order_note(sprintf(__('Google Pay payment failed: %s', 'woo-rede'), $error_message));
+                $order->add_order_note('[' . $this->id . '] ' . sprintf(__('Google Pay payment failed: %s', 'woo-rede'), $error_message));
                 wc_add_notice($error_message, 'error');
                 return array(
                     'result' => 'failure',
@@ -578,7 +578,7 @@ final class LknIntegrationRedeForWoocommerceGooglePay extends LknIntegrationRede
 
         } catch (Exception $e) {
             /* translators: %s: The error message returned when a Google Pay payment fails. */
-            $order->add_order_note(sprintf(__('Google Pay payment error: %s', 'woo-rede'), $e->getMessage()));
+            $order->add_order_note('[' . $this->id . '] ' . sprintf(__('Google Pay payment error: %s', 'woo-rede'), $e->getMessage()));
             wc_add_notice(__('Payment processing failed. Please try again.', 'woo-rede'), 'error');
             return array(
                 'result' => 'failure',

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -883,22 +883,19 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
         $status_note = sprintf('Rede[%s]', $return_message);
         $order->add_order_note('[' . $order->get_payment_method() . '] ' . $status_note . ' ' . $note . $card_type_note);
 
-        // Só altera o status se o pedido estiver pendente
-        if ($order->get_status() === 'pending') {
-            if ($return_code == '00') {
-                if ($capture) {
-                    // Status configurável pelo usuário para pagamentos aprovados com captura
-                    $payment_complete_status = $gateway_settings['payment_complete_status'] ?? 'processing';
-                    $order->set_date_paid(current_time('timestamp', true));
-                    $order->update_status($payment_complete_status);
-                } else {
-                    // Para pagamentos credit sem captura, aguardando captura manual
-                    $order->update_status('on-hold', 'Pagamento autorizado, aguardando captura manual.');
-                    wc_reduce_stock_levels($order->get_id());
-                }
+        if ($return_code == '00') {
+            if ($capture) {
+                // Status configurável pelo usuário para pagamentos aprovados com captura
+                $payment_complete_status = $gateway_settings['payment_complete_status'] ?? 'processing';
+                $order->set_date_paid(current_time('timestamp', true));
+                $order->update_status($payment_complete_status);
             } else {
-                $order->update_status('failed', $status_note);
+                // Para pagamentos credit sem captura, aguardando captura manual
+                $order->update_status('on-hold', 'Pagamento autorizado, aguardando captura manual.');
+                wc_reduce_stock_levels($order->get_id());
             }
+        } else {
+            $order->update_status('failed', $status_note);
         }
     }
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -688,7 +688,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
 
         // VALIDAÇÃO DE SEGURANÇA: Verifica autenticidade da requisição
         if (!$this->validate_webhook_security($order, $parameters, 'success')) {
-            $order->add_order_note(__('Security validation failed for 3DS webhook', 'woo-rede'));
+            $order->add_order_note('[' . $order->get_payment_method() . '] ' . __('Security validation failed for 3DS webhook', 'woo-rede'));
             return new WP_Error('security_validation_failed', __('Security validation failed', 'woo-rede'), array('status' => 403));
         }
 
@@ -700,7 +700,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
             wp_safe_redirect($redirect_url);
             exit;
         } catch (Exception $e) {
-            $order->add_order_note(__('Error processing 3DS success: ', 'woo-rede') . $e->getMessage());
+            $order->add_order_note('[' . $order->get_payment_method() . '] ' . __('Error processing 3DS success: ', 'woo-rede') . $e->getMessage());
             return new WP_REST_Response(array('status' => 'error', 'message' => $e->getMessage()), 500);
         }
     }
@@ -848,7 +848,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
         }
 
         // Marca pedido como falhado
-        $order->add_order_note(__('3D Secure authentication failed', 'woo-rede'));
+        $order->add_order_note('[' . $order->get_payment_method() . '] ' . __('3D Secure authentication failed', 'woo-rede'));
         $order->update_status('failed');
         $order->save();
         
@@ -881,7 +881,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
         // Adiciona informação sobre o tipo de cartão detectado na nota
         $card_type_note = sprintf(' [Card Type: %s, Capture: %s]', $saved_card_type, $capture ? 'Yes' : 'No');
         $status_note = sprintf('Rede[%s]', $return_message);
-        $order->add_order_note($status_note . ' ' . $note . $card_type_note);
+        $order->add_order_note('[' . $order->get_payment_method() . '] ' . $status_note . ' ' . $note . $card_type_note);
 
         // Só altera o status se o pedido estiver pendente
         if ($order->get_status() === 'pending') {

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoCredit.php
@@ -510,7 +510,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
 
         if ($convert_to_brl_enabled) {
             $order->add_order_note(
-                sprintf(
+                '[' . $this->id . '] ' . sprintf(
                     // translators: %s is the original order currency code (e.g., USD, EUR, etc.)
                     __('Order currency %s converted to BRL.', 'woo-rede'),
                     $order_currency,
@@ -694,14 +694,14 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
             // Adiciona nota de status do pagamento estilo Maxipago[Success.] ou Maxipago[Failed.]
             if (isset($xml_decode['responseCode']) && "0" == $xml_decode['responseCode']) {
                 $order->add_order_note(
-                    sprintf(
+                    '[' . $this->id . '] ' . sprintf(
                         'Maxipago[Success.] %s',
                         $xml_decode['processorMessage'] ?? ''
                     )
                 );
             } else {
                 $order->add_order_note(
-                    sprintf(
+                    '[' . $this->id . '] ' . sprintf(
                         'Maxipago[Failed.] %s',
                         $xml_decode['processorMessage'] ?? ''
                     )
@@ -877,7 +877,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
 
                     if (is_wp_error($response)) {
                         $error_message = $response->get_error_message();
-                        $order->add_order_note('Maxipago[Refund Error] ' . esc_attr($error_message));
+                        $order->add_order_note('[' . $this->id . '] Maxipago[Refund Error] ' . esc_attr($error_message));
                         $order->save();
                         return false;
                     } else {
@@ -921,7 +921,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
                         ),
                     ));
                 } catch (Exception $e) {
-                    $order->add_order_note('Maxipago[Refund Error] ' . sanitize_text_field($e->getMessage()));
+                    $order->add_order_note('[' . $this->id . '] Maxipago[Refund Error] ' . sanitize_text_field($e->getMessage()));
                     $order->save();
                     return false;
                 }
@@ -929,7 +929,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoCredit extends LknIntegrat
                 return true;
             } else {
                 $order->add_order_note(
-                    'Maxipago[Refund Error] ' . esc_attr__('Total refund already processed, check the order notes block.', 'woo-rede')
+                    '[' . $this->id . '] Maxipago[Refund Error] ' . esc_attr__('Total refund already processed, check the order notes block.', 'woo-rede')
                 );
                 $order->save();
                 return false;

--- a/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcMaxipagoDebit.php
@@ -410,14 +410,14 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
             // Adiciona nota de status do pagamento estilo Maxipago[Success.] ou Maxipago[Failed.]
             if (isset($xml_decode['responseCode']) && "0" == $xml_decode['responseCode']) {
                 $order->add_order_note(
-                    sprintf(
+                    '[' . $this->id . '] ' . sprintf(
                         'Maxipago[Success.] %s',
                         $xml_decode['processorMessage'] ?? ''
                     )
                 );
             } else {
                 $order->add_order_note(
-                    sprintf(
+                    '[' . $this->id . '] ' . sprintf(
                         'Maxipago[Failed.] %s',
                         $xml_decode['processorMessage'] ?? ''
                     )
@@ -453,7 +453,7 @@ final class LknIntegrationRedeForWoocommerceWcMaxipagoDebit extends LknIntegrati
 
         if ($convert_to_brl_enabled) {
             $order->add_order_note(
-                sprintf(
+                '[' . $this->id . '] ' . sprintf(
                     // translators: %s is the original order currency code (e.g., USD, EUR, etc.)
                     __('Order currency %s converted to BRL.', 'woo-rede'),
                     $order_currency,

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeAbstract.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeAbstract.php
@@ -247,7 +247,7 @@ abstract class LknIntegrationRedeForWoocommerceWcRedeAbstract extends WC_Payment
         /* translators: %s: return message from payment processor */
         $status_note = sprintf('Rede[%s]', $transaction->getReturnMessage());
 
-        $order->add_order_note($status_note . ' ' . $note);
+        $order->add_order_note('[' . $this->id . '] ' . $status_note . ' ' . $note);
 
         // Só altera o status se o pedido estiver pendente
         if ($order->get_status() === 'pending') {

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -720,23 +720,20 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
         $status_note = sprintf('Rede[%s]', $return_message);
         $order->add_order_note('[' . $this->id . '] ' . $status_note . ' ' . $note);
 
-        // Só altera o status se o pedido estiver pendente
-        if ($order->get_status() === 'pending') {
-            if ($return_code == '00') {
-                if ($capture) {
-                    // Status configurável pelo usuário para pagamentos aprovados com captura
-                    $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
-                    $order->set_date_paid(current_time('timestamp', true));
-                    $order->update_status($payment_complete_status);
-                    apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
-                } else {
-                    // Para pagamentos sem captura, sempre aguardando
-                    $order->update_status('on-hold');
-                    wc_reduce_stock_levels($order->get_id());
-                }
+        if ($return_code == '00') {
+            if ($capture) {
+                // Status configurável pelo usuário para pagamentos aprovados com captura
+                $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
+                $order->set_date_paid(current_time('timestamp', true));
+                $order->update_status($payment_complete_status);
+                apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
             } else {
-                $order->update_status('failed', $status_note);
+                // Para pagamentos sem captura, sempre aguardando
+                $order->update_status('on-hold');
+                wc_reduce_stock_levels($order->get_id());
             }
+        } else {
+            $order->update_status('failed', $status_note);
         }
 
         WC()->cart->empty_cart();

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeCredit.php
@@ -718,7 +718,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
         // Adiciona notas ao pedido
         /* translators: %s: return message from payment processor */
         $status_note = sprintf('Rede[%s]', $return_message);
-        $order->add_order_note($status_note . ' ' . $note);
+        $order->add_order_note('[' . $this->id . '] ' . $status_note . ' ' . $note);
 
         // Só altera o status se o pedido estiver pendente
         if ($order->get_status() === 'pending') {
@@ -999,7 +999,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
 
             if ($convert_to_brl_enabled) {
                 $order->add_order_note(
-                    sprintf(
+                    '[' . $this->id . '] ' . sprintf(
                         // translators: %s is the original order currency code (e.g., USD, EUR, etc.)
                         __('Order currency %s converted to BRL.', 'woo-rede'),
                         $order_currency,
@@ -1189,13 +1189,13 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
             $order_currency = method_exists($order, 'get_currency') ? $order->get_currency() : 'BRL';
 
             if (!empty($order->get_meta('_wc_rede_transaction_canceled'))) {
-                $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Total refund already processed, check the order notes block.', 'woo-rede'));
+                $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Total refund already processed, check the order notes block.', 'woo-rede'));
                 $order->save();
                 return false;
             }
 
             if (! $order || ! $order->get_meta('_wc_rede_transaction_id')) {
-                $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Order or transaction invalid for refund.', 'woo-rede'));
+                $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Order or transaction invalid for refund.', 'woo-rede'));
                 $order->save();
                 return false;
             }
@@ -1216,7 +1216,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
                 try {
                     if ($amount > 0) {
                         if (isset($amount) && ($amount > 0 && $amount < $totalAmount) || ($is_converted && $amount > 0 && $amount < $amount_converted)) {
-                            $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Partial refunds are not allowed. You must refund the total order amount.', 'woo-rede'));
+                            $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Partial refunds are not allowed. You must refund the total order amount.', 'woo-rede'));
                             $order->save();
                             return false;
                         } elseif ($order->get_total() == $amount || ($is_converted && $amount == $amount_converted)) {
@@ -1237,15 +1237,15 @@ final class LknIntegrationRedeForWoocommerceWcRedeCredit extends LknIntegrationR
                         } else {
                             $formatted_amount = wc_price($amount, array('currency' => $order_currency));
                         }
-                        $order->add_order_note(esc_attr__('Refunded:', 'woo-rede') . ' ' . $formatted_amount);
+                        $order->add_order_note('[' . $this->id . '] ' . esc_attr__('Refunded:', 'woo-rede') . ' ' . $formatted_amount);
                         $order->save();
                     } else {
-                        $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Invalid refund amount.', 'woo-rede'));
+                        $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Invalid refund amount.', 'woo-rede'));
                         $order->save();
                         return false;
                     }
                 } catch (Exception $e) {
-                    $order->add_order_note('Rede[Refund Error] ' . sanitize_text_field($e->getMessage()));
+                    $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . sanitize_text_field($e->getMessage()));
                     $order->save();
                     return false;
                 }

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -157,7 +157,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
         
         /* translators: %s: return message from payment processor */
         $status_note = sprintf('Rede[%s]', $return_message);
-        $order->add_order_note($status_note . ' ' . $note);
+        $order->add_order_note('[' . $this->id . '] ' . $status_note . ' ' . $note);
 
         // Só altera o status se o pedido estiver pendente
         if ($order->get_status() === 'pending') {
@@ -495,11 +495,11 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
         
         // Adiciona nota sobre o retorno do 3DS
         if ($threeds_status === 'ok') {
-            $order->add_order_note(__('Customer returned from 3D Secure authentication - Success', 'woo-rede'));
+            $order->add_order_note('[' . $this->id . '] ' . __('Customer returned from 3D Secure authentication - Success', 'woo-rede'));
             // Redireciona para a página de confirmação em caso de sucesso
             $redirect_url = $order->get_checkout_order_received_url();
         } else {
-            $order->add_order_note(__('Customer returned from 3D Secure authentication - Failure', 'woo-rede'));
+            $order->add_order_note('[' . $this->id . '] ' . __('Customer returned from 3D Secure authentication - Failure', 'woo-rede'));
             $order->update_status('failed');
             
             // Redireciona para a página de checkout em caso de falha
@@ -1354,7 +1354,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
 
             if ($convert_to_brl_enabled) {
                 $order->add_order_note(
-                    sprintf(
+                    '[' . $this->id . '] ' . sprintf(
                         // translators: %s is the original order currency code (e.g., USD, EUR, etc.)
                         __('Order currency %s converted to BRL.', 'woo-rede'),
                         $order_currency,
@@ -1378,7 +1378,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
                 if (isset($transaction_response['threeDSecure']) && isset($transaction_response['threeDSecure']['url']) && !empty($transaction_response['threeDSecure']['url'])) {
                     
                     // Add order note
-                    $order->add_order_note(__('3D Secure authentication required. Customer redirected to bank authentication.', 'woo-rede'));
+                    $order->add_order_note('[' . $this->id . '] ' . __('3D Secure authentication required. Customer redirected to bank authentication.', 'woo-rede'));
                     
                     return array(
                         'result' => 'success',
@@ -1407,7 +1407,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
                         );
                         $order->save();
                         
-                        $order->add_order_note(__('Payment processed successfully without 3D Secure authentication.', 'woo-rede'));
+                        $order->add_order_note('[' . $this->id . '] ' . __('Payment processed successfully without 3D Secure authentication.', 'woo-rede'));
                         
                         return array(
                             'result' => 'success',
@@ -1633,13 +1633,13 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
             $order_currency = method_exists($order, 'get_currency') ? $order->get_currency() : 'BRL';
 
             if (!empty($order->get_meta('_wc_rede_transaction_canceled'))) {
-                $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Total refund already processed, check the order notes block.', 'woo-rede'));
+                $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Total refund already processed, check the order notes block.', 'woo-rede'));
                 $order->save();
                 return false;
             }
 
             if (! $order || ! $order->get_meta('_wc_rede_transaction_id')) {
-                $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Order or transaction invalid for refund.', 'woo-rede'));
+                $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Order or transaction invalid for refund.', 'woo-rede'));
                 $order->save();
                 return false;
             }
@@ -1660,7 +1660,7 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
                 try {
                     if ($amount > 0) {
                         if (isset($amount) && ($amount > 0 && $amount < $totalAmount) || ($is_converted && $amount > 0 && $amount < $amount_converted)) {
-                            $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Partial refunds are not allowed. You must refund the total order amount.', 'woo-rede'));
+                            $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Partial refunds are not allowed. You must refund the total order amount.', 'woo-rede'));
                             $order->save();
                             return false;
                         } elseif ($order->get_total() == $amount || ($is_converted && $amount == $amount_converted)) {
@@ -1681,15 +1681,15 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
                         } else {
                             $formatted_amount = wc_price($amount, array('currency' => $order_currency));
                         }
-                        $order->add_order_note(esc_attr__('Refunded:', 'woo-rede') . ' ' . $formatted_amount);
+                        $order->add_order_note('[' . $this->id . '] ' . esc_attr__('Refunded:', 'woo-rede') . ' ' . $formatted_amount);
                         $order->save();
                     } else {
-                        $order->add_order_note('Rede[Refund Error] ' . esc_attr__('Invalid refund amount.', 'woo-rede'));
+                        $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . esc_attr__('Invalid refund amount.', 'woo-rede'));
                         $order->save();
                         return false;
                     }
                 } catch (Exception $e) {
-                    $order->add_order_note('Rede[Refund Error] ' . sanitize_text_field($e->getMessage()));
+                    $order->add_order_note('[' . $this->id . '] Rede[Refund Error] ' . sanitize_text_field($e->getMessage()));
                     $order->save();
                     return false;
                 }

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -159,23 +159,20 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
         $status_note = sprintf('Rede[%s]', $return_message);
         $order->add_order_note('[' . $this->id . '] ' . $status_note . ' ' . $note);
 
-        // Só altera o status se o pedido estiver pendente
-        if ($order->get_status() === 'pending') {
-            if ($return_code == '00') {
-                if ($capture) {
-                    // Status configurável pelo usuário para pagamentos aprovados com captura
-                    $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
-                    $order->set_date_paid(current_time('timestamp', true));
-                    $order->update_status($payment_complete_status);
-                    apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
-                } else {
-                    // Para pagamentos credit sem captura, aguardando captura manual
-                    $order->update_status('on-hold');
-                    wc_reduce_stock_levels($order->get_id());
-                }
+        if ($return_code == '00') {
+            if ($capture) {
+                // Status configurável pelo usuário para pagamentos aprovados com captura
+                $payment_complete_status = $this->get_option('payment_complete_status', 'processing');
+                $order->set_date_paid(current_time('timestamp', true));
+                $order->update_status($payment_complete_status);
+                apply_filters("integration_rede_for_woocommerce_change_order_status", $order, $this);
             } else {
-                $order->update_status('failed', $status_note);
+                // Para pagamentos credit sem captura, aguardando captura manual
+                $order->update_status('on-hold');
+                wc_reduce_stock_levels($order->get_id());
             }
+        } else {
+            $order->update_status('failed', $status_note);
         }
 
         // Esvazia o carrinho apenas se disponível (contexto de checkout regular)

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: rede, PIX, cartao credito, itau, pagamento  
 Requires at least: 5.0  
 Tested up to: 6.9  
-Stable tag: 5.4.3
+Stable tag: 5.4.4
 Requires PHP: 8.0  
 License: GPLv3 or later  
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt

--- a/README.txt
+++ b/README.txt
@@ -125,6 +125,10 @@ A: Yes — tested up to WordPress 6.8.
 
 ## Changelog
 
+### 5.4.4 - 2026/06/03
+- Fix in custom order notes logic.
+- Fix in order status update logic.
+
 ### 5.4.3 - 2026/05/28
 - Fix in error log logic for 3DS transactions.
 

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -16,6 +16,7 @@
  * Plugin Name:       Integration Rede Itaú for WooCommerce — Payment PIX, Credit Card and Debit
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
  * Version:           5.4.3
+ * Requires PHP:      8.2
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/wordpress
  * License:           GPL-3.0+

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede Itaú for WooCommerce — Payment PIX, Credit Card and Debit
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           5.4.3
+ * Version:           5.4.4
  * Requires PHP:      8.2
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br/wordpress

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.4.3');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.4.4');
 }
 
 if (! defined('LKN_WC_REDE_WPP_NUMBER')) {


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 6.9

Versão estável: 5.4.4

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste nas notas customizadas.
* Ajuste na mudança do status do pedido.