### PR TITLE
5.4.8 - integration-rede-for-woocommerce(Ajuste na mensagem do notice)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -10,7 +10,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.7"
+  DEPLOY_TAG: "5.4.8"
 
 jobs:
   release-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ env:
   PLUGIN_NAME: woo-rede
   DIR_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.7"
+  DEPLOY_TAG: "5.4.8"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: woo-rede
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "5.4.7"
+  DEPLOY_TAG: "5.4.8"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.4.8 - 14/08/2026
+* Ajuste: Mudança no texto de notificação ao detectar pagamento com frictionless no 3DS.
+  
 # 5.4.7 - 10/08/2026
 * Segurança: Validação server-to-server no webhook PIX FREE (redePixListenerLegacy) para prevenir webhook forgery não autenticado.
 

--- a/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcEndpoint.php
@@ -1432,7 +1432,7 @@ final class LknIntegrationRedeForWoocommerceWcEndpoint
         }
 
         // Processa status do pedido usando a função específica para 3DS (inclui lógica de auto_capture)
-        $this->process_3ds_order_status($order, $webhook_data, '3D Secure authentication completed');
+        $this->process_3ds_order_status($order, $webhook_data, __('3D Secure authentication completed with challenge', 'woo-rede'));
     }
 
     /**

--- a/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
+++ b/Includes/LknIntegrationRedeForWoocommerceWcRedeDebit.php
@@ -1508,7 +1508,13 @@ final class LknIntegrationRedeForWoocommerceWcRedeDebit extends LknIntegrationRe
                         );
                         $order->save();
                         
-                        $order->add_order_note('[' . $this->id . '] ' . __('Payment processed successfully without 3D Secure authentication.', 'woo-rede'));
+                        if (isset($transaction_response['threeDSecure'])) {
+                            // 3DS autenticado sem desafio (frictionless)
+                            $order->add_order_note('[' . $this->id . '] ' . __('3D Secure authentication completed without challenge (frictionless).', 'woo-rede'));
+                        } else {
+                            // Transação aprovada sem autenticação 3D Secure
+                            $order->add_order_note('[' . $this->id . '] ' . __('Payment processed successfully without 3D Secure authentication.', 'woo-rede'));
+                        }
                         
                         return array(
                             'result' => 'success',

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://www.linknacional.com/wordpress/plugins/
 Tags: rede, PIX, cartao credito, itau, pagamento  
 Requires at least: 6.0
 Tested up to: 7.0  
-Stable tag: 5.4.7
+Stable tag: 5.4.8
 Requires PHP: 8.2
 License: GPLv3 or later  
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -124,6 +124,9 @@ A: Yes — tested up to WordPress 6.8.
 ---
 
 ## Changelog
+
+### 5.4.8 - 2026-08-14
+* Adjustment: Updated the notification text when detecting a frictionless 3DS payment.
 
 ### 5.4.7 - 2026-08-10
 * Security: Server-to-server validation added to PIX FREE webhook (redePixListenerLegacy) to prevent unauthenticated webhook forgery.

--- a/README.txt
+++ b/README.txt
@@ -280,6 +280,9 @@ A: Yes — tested up to WordPress 6.8.
 
 ## Upgrade Notice
 
+### 5.4.8 - 2026-08-14
+* Adjustment: Updated the notification text when detecting a frictionless 3DS payment.
+
 ### 5.4.7 - 2026-08-10
 * Security: Server-to-server validation added to PIX FREE webhook (redePixListenerLegacy) to prevent unauthenticated webhook forgery.
 

--- a/integration-rede-for-woocommerce.php
+++ b/integration-rede-for-woocommerce.php
@@ -15,7 +15,7 @@
  * @wordpress-plugin
  * Plugin Name:       Integration Rede Itaú for WooCommerce — Payment PIX, Credit Card and Debit
  * Description:       Receba pagamentos por meio de cartões de crédito e débito, de diferentes bandeiras, usando a tecnologia de autenticação 3DS e recursos avançados de proteção contra fraudes.
- * Version:           5.4.7
+ * Version:           5.4.8
  * Requires at least: 6.0
  * Requires PHP:      8.2
  * Author:            Link Nacional

--- a/lkn-integration-rede-for-woocommerce-file.php
+++ b/lkn-integration-rede-for-woocommerce-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION')) {
-    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.4.7');
+    define('INTEGRATION_REDE_FOR_WOOCOMMERCE_VERSION', '5.4.8');
 }
 
 if (! defined('LKN_WC_REDE_WPP_NUMBER')) {


### PR DESCRIPTION
# Integration Rede for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, pagamento, rede, maxipago, credit, debit, pix, gateway

Testado até: 7.0

Versão estável: 5.4.8

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Integre pagamentos via Rede e Maxipago à sua loja WooCommerce com suporte completo a cartão de crédito, débito e PIX.

## Descrição

O Integration Rede for WooCommerce oferece integração completa com os gateways de pagamento Rede e Maxipago, permitindo que sua loja WooCommerce aceite pagamentos via:

- **Cartão de Crédito** (Rede e Maxipago)
- **Cartão de Débito** (Rede e Maxipago)  
- **PIX** (Rede)

A [Rede](https://www.userede.com.br) é uma das principais adquirentes do Brasil, oferecendo soluções seguras e confiáveis para processamento de pagamentos. O [Maxipago](https://www.maxipago.com) é uma plataforma robusta de gateway de pagamentos com ampla cobertura internacional.

**Recursos Principais**

- Sistema de parcelamento inteligente com cálculo de juros
- Validação 3DS para débito Maxipago
- Cartão animado no checkout
- Sistema de cron para verificação automática de PIX
- Compatibilidade com checkout por shortcode
- Suporte a reembolsos automáticos
- Logs detalhados de transações
- Conversão de moeda
- Compatibilidade com editor de blocos WooCommerce

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Integration Rede for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Integration Rede for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os gateways disponíveis: 'Rede Credit', 'Rede Debit', 'Rede PIX', 'Maxipago Credit', 'Maxipago Debit'.
3. Configure as credenciais de API necessárias para cada gateway.
4. Defina as opções de parcelamento, juros e limites conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Rede e Maxipago com múltiplos métodos de pagamento.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste: Mudança no texto de notificação ao detectar pagamento com frictionless no 3DS.